### PR TITLE
feat: validate marimo notebooks with styling improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,118 @@
+# Slidev + Marimo
+
+How amazing would it be to have Python code running on slides? And what if those slides were interactive?
+
+> **Enter `slidev` + `marimo`**
+
+## Two implementations
+
+This repo has two ways to run marimo notebooks as slides:
+
+### 1. Marimo Islands
+
+```bash
+slidev islands-example.md
+```
+
+Powered by Pyodide and WebAssembly. Your slides run fully in the browser - no server, no kernel, just open and go. The tradeoff: you're limited to packages available in Pyodide, and compute happens in your browser.
+
+### 2. Marimo Live
+
+```bash
+# Start the kernel (with sandbox for automatic deps)
+marimo edit examples/notebook.py --sandbox --headless --port 2718 --no-token --allow-origins "*"
+
+# Start slidev
+slidev examples/marimo-live-test.md
+```
+
+A live marimo kernel runs on your machine. Instead of the traditional marimo notebook UI, your frontend is Slidev slides. This lets you use any Python package, any dependency, full compute power - no Pyodide limitations.
+
+## Ergonomics
+
+Since Slidev slides are just markdown files, we made it possible to write marimo cells as simple code blocks:
+
+~~~markdown
+```marimo
+import matplotlib.pyplot as plt
+plt.plot([1, 2, 3], [1, 4, 9])
+```
+~~~
+
+These code blocks power the interactive cells you see on the slides.
+
+For Marimo Live, you can reference cells from your notebook by name or index:
+
+~~~markdown
+```marimo-live cell=plot_chart
+```
+
+```marimo-live cell=2
+```
+~~~
+
+This keeps your Python code in one place with full IDE support.
+
+---
+
+## Installation
+
+```bash
+# Clone the repo
+git clone <repo-url>
+cd slidev-marimo-nb-validation
+
+# Install dependencies
+bun install
+```
+
+## Usage
+
+### Marimo Live (recommended for full Python)
+
+1. **Start the marimo kernel** with sandbox mode (auto-installs deps from notebook):
+
+```bash
+marimo edit examples/notebook.py --sandbox --headless --port 2718 --no-token --allow-origins "*"
+```
+
+2. **Start Slidev**:
+
+```bash
+slidev examples/marimo-live-test.md
+```
+
+3. Open http://localhost:3030 (or the port shown in terminal)
+
+### Marimo Islands (browser-only)
+
+```bash
+slidev islands-example.md
+```
+
+No kernel needed - runs entirely in the browser.
+
+## Examples
+
+See `examples/` directory:
+
+- `marimo-live-test.md` - Demo slides with sliders, charts, data explorer
+- `notebook.py` - Marimo notebook with polars, altair, and UI elements
+
+## Adding dependencies to your notebook
+
+For `--sandbox` mode to work, add a PEP 723 script header to your notebook:
+
+```python
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+#     "polars",
+#     "altair",
+# ]
+# ///
+
+import marimo
+# ... rest of notebook
+```

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,1764 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "slidev-marimo",
+      "dependencies": {
+        "@slidev/theme-default": "^0.25.0",
+        "slidev-marimo-islands": "file:slidev-addon-marimo-islands",
+        "slidev-marimo-live": "file:slidev-addon-marimo-live",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "2.3.7",
+      },
+    },
+  },
+  "packages": {
+    "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
+
+    "@antfu/ni": ["@antfu/ni@28.2.0", "", { "dependencies": { "ansis": "^4.2.0", "fzf": "^0.5.2", "package-manager-detector": "^1.6.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15" }, "bin": { "ni": "bin/ni.mjs", "nci": "bin/nci.mjs", "nr": "bin/nr.mjs", "nup": "bin/nup.mjs", "nd": "bin/nd.mjs", "nlx": "bin/nlx.mjs", "na": "bin/na.mjs", "nun": "bin/nun.mjs" } }, "sha512-+pnatqUMTpi1g/VxbaTsX9UxibTp5oWCMbfUAQPV91UL9lTIMmlU2uvG8bDETDJ0kJdsZT8zLBctKLJOeL5jmg=="],
+
+    "@antfu/utils": ["@antfu/utils@9.3.0", "", {}, "sha512-9hFT4RauhcUzqOE4f1+frMKLZrgNog5b06I7VmZQV1BkvwvqrbC8EBZf3L1eEL2AKb6rNKjER0sEvJiSP1FXEA=="],
+
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
+
+    "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@2.0.2", "", { "dependencies": { "bidi-js": "^1.0.3", "css-tree": "^2.3.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-x1KXOatwofR6ZAYzXRBL5wrdV0vwNxlTCK9NCuLqAzQYARqGcvFwiJA6A1ERuh+dgeA4Dxm3JBYictIes+SqUQ=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.28.6", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.28.6", "", {}, "sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg=="],
+
+    "@babel/core": ["@babel/core@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/generator": "^7.28.6", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-module-transforms": "^7.28.6", "@babel/helpers": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/template": "^7.28.6", "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw=="],
+
+    "@babel/generator": ["@babel/generator@7.28.6", "", { "dependencies": { "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw=="],
+
+    "@babel/helper-annotate-as-pure": ["@babel/helper-annotate-as-pure@7.27.3", "", { "dependencies": { "@babel/types": "^7.27.3" } }, "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.28.6", "", { "dependencies": { "@babel/compat-data": "^7.28.6", "@babel/helper-validator-option": "^7.27.1", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA=="],
+
+    "@babel/helper-create-class-features-plugin": ["@babel/helper-create-class-features-plugin@7.28.6", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^7.27.3", "@babel/helper-member-expression-to-functions": "^7.28.5", "@babel/helper-optimise-call-expression": "^7.27.1", "@babel/helper-replace-supers": "^7.28.6", "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1", "@babel/traverse": "^7.28.6", "semver": "^6.3.1" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+
+    "@babel/helper-member-expression-to-functions": ["@babel/helper-member-expression-to-functions@7.28.5", "", { "dependencies": { "@babel/traverse": "^7.28.5", "@babel/types": "^7.28.5" } }, "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.28.6", "", { "dependencies": { "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.6", "", { "dependencies": { "@babel/helper-module-imports": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA=="],
+
+    "@babel/helper-optimise-call-expression": ["@babel/helper-optimise-call-expression@7.27.1", "", { "dependencies": { "@babel/types": "^7.27.1" } }, "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw=="],
+
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.28.6", "", {}, "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug=="],
+
+    "@babel/helper-replace-supers": ["@babel/helper-replace-supers@7.28.6", "", { "dependencies": { "@babel/helper-member-expression-to-functions": "^7.28.5", "@babel/helper-optimise-call-expression": "^7.27.1", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg=="],
+
+    "@babel/helper-skip-transparent-expression-wrappers": ["@babel/helper-skip-transparent-expression-wrappers@7.27.1", "", { "dependencies": { "@babel/traverse": "^7.27.1", "@babel/types": "^7.27.1" } }, "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
+
+    "@babel/helpers": ["@babel/helpers@7.28.6", "", { "dependencies": { "@babel/template": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw=="],
+
+    "@babel/parser": ["@babel/parser@7.28.6", "", { "dependencies": { "@babel/types": "^7.28.6" }, "bin": "./bin/babel-parser.js" }, "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ=="],
+
+    "@babel/plugin-syntax-jsx": ["@babel/plugin-syntax-jsx@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w=="],
+
+    "@babel/plugin-syntax-typescript": ["@babel/plugin-syntax-typescript@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A=="],
+
+    "@babel/plugin-transform-typescript": ["@babel/plugin-transform-typescript@7.28.6", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^7.27.3", "@babel/helper-create-class-features-plugin": "^7.28.6", "@babel/helper-plugin-utils": "^7.28.6", "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw=="],
+
+    "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+
+    "@babel/traverse": ["@babel/traverse@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/generator": "^7.28.6", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.6", "@babel/template": "^7.28.6", "@babel/types": "^7.28.6", "debug": "^4.3.1" } }, "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg=="],
+
+    "@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
+
+    "@biomejs/biome": ["@biomejs/biome@2.3.7", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.7", "@biomejs/cli-darwin-x64": "2.3.7", "@biomejs/cli-linux-arm64": "2.3.7", "@biomejs/cli-linux-arm64-musl": "2.3.7", "@biomejs/cli-linux-x64": "2.3.7", "@biomejs/cli-linux-x64-musl": "2.3.7", "@biomejs/cli-win32-arm64": "2.3.7", "@biomejs/cli-win32-x64": "2.3.7" }, "bin": { "biome": "bin/biome" } }, "sha512-CTbAS/jNAiUc6rcq94BrTB8z83O9+BsgWj2sBCQg9rD6Wkh2gjfR87usjx0Ncx0zGXP1NKgT7JNglay5Zfs9jw=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LirkamEwzIUULhXcf2D5b+NatXKeqhOwilM+5eRkbrnr6daKz9rsBL0kNZ16Hcy4b8RFq22SG4tcLwM+yx/wFA=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-Q4TO633kvrMQkKIV7wmf8HXwF0dhdTD9S458LGE24TYgBjSRbuhvio4D5eOQzirEYg6eqxfs53ga/rbdd8nBKg=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-inHOTdlstUBzgjDcx0ge71U4SVTbwAljmkfi3MC5WzsYCRhancqfeL+sa4Ke6v2ND53WIwCFD5hGsYExoI3EZQ=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-/afy8lto4CB8scWfMdt+NoCZtatBUF62Tk3ilWH2w8ENd5spLhM77zKlFZEvsKJv9AFNHknMl03zO67CiklL2Q=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.7", "", { "os": "linux", "cpu": "x64" }, "sha512-fJMc3ZEuo/NaMYo5rvoWjdSS5/uVSW+HPRQujucpZqm2ZCq71b8MKJ9U4th9yrv2L5+5NjPF0nqqILCl8HY/fg=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.7", "", { "os": "linux", "cpu": "x64" }, "sha512-CQUtgH1tIN6e5wiYSJqzSwJumHYolNtaj1dwZGCnZXm2PZU1jOJof9TsyiP3bXNDb+VOR7oo7ZvY01If0W3iFQ=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-aJAE8eCNyRpcfx2JJAtsPtISnELJ0H4xVVSwnxm13bzI8RwbXMyVtxy2r5DV1xT3WiSP+7LxORcApWw0LM8HiA=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.7", "", { "os": "win32", "cpu": "x64" }, "sha512-pulzUshqv9Ed//MiE8MOUeeEkbkSHVDVY5Cz5wVAnH1DUqliCQG3j6s1POaITTFqFfo7AVIx2sWdKpx/GS+Nqw=="],
+
+    "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
+
+    "@chevrotain/cst-dts-gen": ["@chevrotain/cst-dts-gen@11.0.3", "", { "dependencies": { "@chevrotain/gast": "11.0.3", "@chevrotain/types": "11.0.3", "lodash-es": "4.17.21" } }, "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ=="],
+
+    "@chevrotain/gast": ["@chevrotain/gast@11.0.3", "", { "dependencies": { "@chevrotain/types": "11.0.3", "lodash-es": "4.17.21" } }, "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q=="],
+
+    "@chevrotain/regexp-to-ast": ["@chevrotain/regexp-to-ast@11.0.3", "", {}, "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA=="],
+
+    "@chevrotain/types": ["@chevrotain/types@11.0.3", "", {}, "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ=="],
+
+    "@chevrotain/utils": ["@chevrotain/utils@11.0.3", "", {}, "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ=="],
+
+    "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
+
+    "@csstools/css-calc": ["@csstools/css-calc@2.1.4", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="],
+
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@3.1.0", "", { "dependencies": { "@csstools/color-helpers": "^5.1.0", "@csstools/css-calc": "^2.1.4" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA=="],
+
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@3.0.5", "", { "peerDependencies": { "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ=="],
+
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@3.0.4", "", {}, "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw=="],
+
+    "@drauu/core": ["@drauu/core@1.0.0", "", {}, "sha512-r1fPyuKaGuNHc8vxRFUT8LxqWjJ3nx+U+zsHcEOurmJoB7uN+zpFw5kTLInfdfvQZ+qF/ebQjw1AwbGcc1XKsQ=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.2", "", { "os": "android", "cpu": "arm" }, "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.2", "", { "os": "android", "cpu": "arm64" }, "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.2", "", { "os": "android", "cpu": "x64" }, "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.2", "", { "os": "linux", "cpu": "arm" }, "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.2", "", { "os": "linux", "cpu": "ia32" }, "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.2", "", { "os": "linux", "cpu": "none" }, "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.2", "", { "os": "linux", "cpu": "none" }, "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.2", "", { "os": "linux", "cpu": "none" }, "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.2", "", { "os": "linux", "cpu": "x64" }, "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.2", "", { "os": "none", "cpu": "arm64" }, "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.2", "", { "os": "none", "cpu": "x64" }, "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.2", "", { "os": "none", "cpu": "arm64" }, "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.2", "", { "os": "win32", "cpu": "x64" }, "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ=="],
+
+    "@floating-ui/core": ["@floating-ui/core@1.7.4", "", { "dependencies": { "@floating-ui/utils": "^0.2.10" } }, "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.1.1", "", { "dependencies": { "@floating-ui/core": "^1.1.0" } }, "sha512-TpIO93+DIujg3g7SykEAGZMDtbJRrmnYRCNYSjJlvIbGhBjRSNTLVbNeDQBrzy9qDgUbiWdc7KA0uZHZ2tJmiw=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
+
+    "@iconify-json/carbon": ["@iconify-json/carbon@1.2.18", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-Grb13E6r/RqTEV4Sqd/BQR2FUt57U2WLuticJ5H8JbTdHLop1LmdePu3EJJA3Xi8DcWRbD6OnC133hKfOwlgtg=="],
+
+    "@iconify-json/ph": ["@iconify-json/ph@1.2.2", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-PgkEZNtqa8hBGjHXQa4pMwZa93hmfu8FUSjs/nv4oUU6yLsgv+gh9nu28Kqi8Fz9CCVu4hj1MZs9/60J57IzFw=="],
+
+    "@iconify-json/svg-spinners": ["@iconify-json/svg-spinners@1.2.4", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-ayn0pogFPwJA1WFZpDnoq9/hjDxN+keeCMyThaX4d3gSJ3y0mdKUxIA/b1YXWGtY9wVtZmxwcvOIeEieG4+JNg=="],
+
+    "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
+
+    "@iconify/utils": ["@iconify/utils@3.1.0", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/types": "^2.0.0", "mlly": "^1.8.0" } }, "sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw=="],
+
+    "@jest/schemas": ["@jest/schemas@29.6.3", "", { "dependencies": { "@sinclair/typebox": "^0.27.8" } }, "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@leichtgewicht/ip-codec": ["@leichtgewicht/ip-codec@2.0.5", "", {}, "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="],
+
+    "@lillallol/outline-pdf": ["@lillallol/outline-pdf@4.0.0", "", { "dependencies": { "@lillallol/outline-pdf-data-structure": "^1.0.3", "pdf-lib": "^1.16.0" } }, "sha512-tILGNyOdI3ukZfU19TNTDVoS0W1nSPlMxCKAm9FPV4OPL786Ur7e1CRLQZWKJP6uaMQsUqSDBCTzISs6lXWdAQ=="],
+
+    "@lillallol/outline-pdf-data-structure": ["@lillallol/outline-pdf-data-structure@1.0.3", "", {}, "sha512-XlK9dERP2n9afkJ23JyJzpmesLgiOHmhqKuGgeytnT+IVGFdAsYl1wLr2o+byXNAN5fveNbc7CCI6RfBsd5FCw=="],
+
+    "@mdit-vue/plugin-component": ["@mdit-vue/plugin-component@3.0.2", "", { "dependencies": { "@types/markdown-it": "^14.1.2", "markdown-it": "^14.1.0" } }, "sha512-Fu53MajrZMOAjOIPGMTdTXgHLgGU9KwTqKtYc6WNYtFZNKw04euSfJ/zFg8eBY/2MlciVngkF7Gyc2IL7e8Bsw=="],
+
+    "@mdit-vue/plugin-frontmatter": ["@mdit-vue/plugin-frontmatter@3.0.2", "", { "dependencies": { "@mdit-vue/types": "3.0.2", "@types/markdown-it": "^14.1.2", "gray-matter": "^4.0.3", "markdown-it": "^14.1.0" } }, "sha512-QKKgIva31YtqHgSAz7S7hRcL7cHXiqdog4wxTfxeQCHo+9IP4Oi5/r1Y5E93nTPccpadDWzAwr3A0F+kAEnsVQ=="],
+
+    "@mdit-vue/types": ["@mdit-vue/types@3.0.2", "", {}, "sha512-00aAZ0F0NLik6I6Yba2emGbHLxv+QYrPH00qQ5dFKXlAo1Ll2RHDXwY7nN2WAfrx2pP+WrvSRFTGFCNGdzBDHw=="],
+
+    "@mermaid-js/parser": ["@mermaid-js/parser@0.6.3", "", { "dependencies": { "langium": "3.3.1" } }, "sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA=="],
+
+    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
+
+    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
+
+    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@nuxt/kit": ["@nuxt/kit@3.21.0", "", { "dependencies": { "c12": "^3.3.3", "consola": "^3.4.2", "defu": "^6.1.4", "destr": "^2.0.5", "errx": "^0.1.0", "exsolve": "^1.0.8", "ignore": "^7.0.5", "jiti": "^2.6.1", "klona": "^2.0.6", "knitwork": "^1.3.0", "mlly": "^1.8.0", "ohash": "^2.0.11", "pathe": "^2.0.3", "pkg-types": "^2.3.0", "rc9": "^2.1.2", "scule": "^1.3.0", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ufo": "^1.6.3", "unctx": "^2.5.0", "untyped": "^2.0.0" } }, "sha512-KMTLK/dsGaQioZzkYUvgfN9le4grNW54aNcA1jqzgVZLcFVy4jJfrJr5WZio9NT2EMfajdoZ+V28aD7BRr4Zfw=="],
+
+    "@pdf-lib/standard-fonts": ["@pdf-lib/standard-fonts@1.0.0", "", { "dependencies": { "pako": "^1.0.6" } }, "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA=="],
+
+    "@pdf-lib/upng": ["@pdf-lib/upng@1.0.1", "", { "dependencies": { "pako": "^1.0.10" } }, "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ=="],
+
+    "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
+
+    "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.53", "", {}, "sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.57.1", "", { "os": "android", "cpu": "arm" }, "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.57.1", "", { "os": "android", "cpu": "arm64" }, "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.57.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.57.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.57.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.57.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.57.1", "", { "os": "linux", "cpu": "arm" }, "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.57.1", "", { "os": "linux", "cpu": "arm" }, "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.57.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.57.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.57.1", "", { "os": "linux", "cpu": "none" }, "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.57.1", "", { "os": "linux", "cpu": "none" }, "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.57.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.57.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.57.1", "", { "os": "linux", "cpu": "none" }, "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.57.1", "", { "os": "linux", "cpu": "none" }, "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.57.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.57.1", "", { "os": "linux", "cpu": "x64" }, "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.57.1", "", { "os": "linux", "cpu": "x64" }, "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.57.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.57.1", "", { "os": "none", "cpu": "arm64" }, "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.57.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.57.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.57.1", "", { "os": "win32", "cpu": "x64" }, "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.57.1", "", { "os": "win32", "cpu": "x64" }, "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA=="],
+
+    "@shikijs/core": ["@shikijs/core@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA=="],
+
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-jdKhfgW9CRtj3Tor0L7+yPwdG3CgP7W+ZEqSsojrMzCjD1e0IxIbwUMDDpYlVBlC08TACg4puwFGkZfLS+56Tw=="],
+
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-DyXsOG0vGtNtl7ygvabHd7Mt5EY8gCNqR9Y7Lpbbd/PbJvgWrqaKzH1JW6H6qFkuUa8aCxoiYVv8/YfFljiQxA=="],
+
+    "@shikijs/langs": ["@shikijs/langs@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0" } }, "sha512-x/42TfhWmp6H00T6uwVrdTJGKgNdFbrEdhaDwSR5fd5zhQ1Q46bHq9EO61SCEWJR0HY7z2HNDMaBZp8JRmKiIA=="],
+
+    "@shikijs/markdown-it": ["@shikijs/markdown-it@3.22.0", "", { "dependencies": { "markdown-it": "^14.1.0", "shiki": "3.22.0" }, "peerDependencies": { "markdown-it-async": "^2.2.0" }, "optionalPeers": ["markdown-it-async"] }, "sha512-l0DehGhJN+JkkzGwULVhE57S9o7zQA2lVfpEjcvpSkxTbhzTEuoKHjuQQUN0VNbYeyj4obZwB4CTVrMijvYaeg=="],
+
+    "@shikijs/monaco": ["@shikijs/monaco@3.22.0", "", { "dependencies": { "@shikijs/core": "3.22.0", "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-4Bi/Gr5+ZVGmILq4ksyWtNbylfHxYB0BDMLR76UsaKOkWNJ/1w+c2s7bIjYnBNydyLVRlp28qntqEvB9EaJu3g=="],
+
+    "@shikijs/themes": ["@shikijs/themes@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0" } }, "sha512-o+tlOKqsr6FE4+mYJG08tfCFDS+3CG20HbldXeVoyP+cYSUxDhrFf3GPjE60U55iOkkjbpY2uC3It/eeja35/g=="],
+
+    "@shikijs/twoslash": ["@shikijs/twoslash@3.22.0", "", { "dependencies": { "@shikijs/core": "3.22.0", "@shikijs/types": "3.22.0", "twoslash": "^0.3.6" }, "peerDependencies": { "typescript": ">=5.5.0" } }, "sha512-GO27UPN+kegOMQvC+4XcLt0Mttyg+n16XKjmoKjdaNZoW+sOJV7FLdv2QKauqUDws6nE3EQPD+TFHEdyyoUBDw=="],
+
+    "@shikijs/types": ["@shikijs/types@3.22.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-491iAekgKDBFE67z70Ok5a8KBMsQ2IJwOWw3us/7ffQkIBCyOQfm/aNwVMBUriP02QshIfgHCBSIYAl3u2eWjg=="],
+
+    "@shikijs/vitepress-twoslash": ["@shikijs/vitepress-twoslash@3.22.0", "", { "dependencies": { "@shikijs/twoslash": "3.22.0", "floating-vue": "^5.2.2", "lz-string": "^1.5.0", "magic-string": "^0.30.21", "markdown-it": "^14.1.0", "mdast-util-from-markdown": "^2.0.2", "mdast-util-gfm": "^3.1.0", "mdast-util-to-hast": "^13.2.1", "ohash": "^2.0.11", "shiki": "3.22.0", "twoslash": "^0.3.6", "twoslash-vue": "^0.3.6", "vue": "^3.5.27" } }, "sha512-E4W4eUHmRVaWhhJO9Phor7xySwKyxMlgzqAnx3/wC9JWxTUKcsWn4gtd4zGtHF9IsrAq0JVkcGdLSx2YoY784A=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
+    "@sinclair/typebox": ["@sinclair/typebox@0.27.8", "", {}, "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="],
+
+    "@slidev/cli": ["@slidev/cli@52.11.5", "", { "dependencies": { "@antfu/ni": "^28.2.0", "@antfu/utils": "^9.3.0", "@iconify-json/carbon": "^1.2.18", "@iconify-json/ph": "^1.2.2", "@iconify-json/svg-spinners": "^1.2.4", "@lillallol/outline-pdf": "^4.0.0", "@shikijs/markdown-it": "^3.21.0", "@shikijs/twoslash": "^3.21.0", "@shikijs/vitepress-twoslash": "^3.21.0", "@slidev/client": "52.11.5", "@slidev/parser": "52.11.5", "@slidev/types": "52.11.5", "@unocss/extractor-mdc": "^66.6.0", "@unocss/reset": "^66.6.0", "@vitejs/plugin-vue": "^6.0.3", "@vitejs/plugin-vue-jsx": "^5.1.3", "ansis": "^4.2.0", "chokidar": "^5.0.0", "cli-progress": "^3.12.0", "connect": "^3.7.0", "fast-deep-equal": "^3.1.3", "fast-glob": "^3.3.3", "get-port-please": "^3.2.0", "global-directory": "^4.0.1", "htmlparser2": "^10.1.0", "is-installed-globally": "^1.0.0", "jiti": "^2.6.1", "katex": "^0.16.28", "local-pkg": "^1.1.2", "lz-string": "^1.5.0", "magic-string": "^0.30.21", "magic-string-stack": "^1.1.0", "markdown-it": "^14.1.0", "markdown-it-footnote": "^4.0.0", "markdown-it-mdc": "^0.2.8", "mlly": "^1.8.0", "monaco-editor": "^0.55.1", "obug": "^2.1.1", "open": "^11.0.0", "pdf-lib": "^1.17.1", "picomatch": "^4.0.3", "plantuml-encoder": "^1.4.0", "postcss-nested": "^7.0.2", "pptxgenjs": "^4.0.1", "prompts": "^2.4.2", "public-ip": "^8.0.0", "resolve-from": "^5.0.0", "resolve-global": "^2.0.0", "semver": "^7.7.3", "shiki": "^3.21.0", "shiki-magic-move": "^1.2.1", "sirv": "^3.0.2", "source-map-js": "^1.2.1", "typescript": "^5.9.3", "unhead": "^2.1.2", "unocss": "^66.6.0", "unplugin-icons": "^23.0.1", "unplugin-vue-components": "^31.0.0", "unplugin-vue-markdown": "^29.2.0", "untun": "^0.1.3", "uqr": "^0.1.2", "vite": "^7.3.1", "vite-plugin-inspect": "^11.3.3", "vite-plugin-remote-assets": "^2.1.0", "vite-plugin-static-copy": "^3.2.0", "vite-plugin-vue-server-ref": "^1.0.0", "vitefu": "^1.1.1", "vue": "^3.5.27", "yaml": "^2.8.2", "yargs": "^18.0.0" }, "peerDependencies": { "playwright-chromium": "^1.10.0" }, "optionalPeers": ["playwright-chromium"], "bin": { "slidev": "bin/slidev.mjs" } }, "sha512-MZJhWsgXHrFiuO3EbEMSZhVn6k6UP19nHwOhDXBtlLk4Dy1BCc99s9AzUjO9NjebRHCr2+3u5irX/2UHVNRoPA=="],
+
+    "@slidev/client": ["@slidev/client@52.11.5", "", { "dependencies": { "@antfu/utils": "^9.3.0", "@iconify-json/carbon": "^1.2.18", "@iconify-json/ph": "^1.2.2", "@iconify-json/svg-spinners": "^1.2.4", "@shikijs/engine-javascript": "^3.21.0", "@shikijs/monaco": "^3.21.0", "@shikijs/vitepress-twoslash": "^3.21.0", "@slidev/parser": "52.11.5", "@slidev/rough-notation": "^0.1.0", "@slidev/types": "52.11.5", "@typescript/ata": "^0.9.8", "@unhead/vue": "^2.1.2", "@unocss/reset": "^66.6.0", "@vueuse/core": "^14.1.0", "@vueuse/math": "^14.1.0", "@vueuse/motion": "^3.0.3", "ansis": "^4.2.0", "drauu": "^1.0.0", "file-saver": "^2.0.5", "floating-vue": "^5.2.2", "fuse.js": "^7.1.0", "katex": "^0.16.28", "lz-string": "^1.5.0", "mermaid": "^11.12.2", "monaco-editor": "^0.55.1", "nanotar": "^0.2.0", "pptxgenjs": "^4.0.1", "recordrtc": "^5.6.2", "shiki": "^3.21.0", "shiki-magic-move": "^1.2.1", "typescript": "^5.9.3", "unocss": "^66.6.0", "vue": "^3.5.27", "vue-router": "^4.6.4", "yaml": "^2.8.2" } }, "sha512-wwnndmO8RL93zNKt7zUrt4qRN/piF/TIAZ4xKS93KGXZ4DOGllqF4AvLPIfuN8+tT6dMeML0u6h65Xrq/b+7eQ=="],
+
+    "@slidev/parser": ["@slidev/parser@52.11.5", "", { "dependencies": { "@antfu/utils": "^9.3.0", "@slidev/types": "52.11.5", "yaml": "^2.8.2" } }, "sha512-+99OtNUTyUPDXfOzeZ7BeS3fzw4v2wSkqfjNN8y1BJ7heM2h2+dJlqLP9wzm/2T2C/XleOWkMFqEUVNTv0sfJg=="],
+
+    "@slidev/rough-notation": ["@slidev/rough-notation@0.1.0", "", { "dependencies": { "roughjs": "^4.6.6" } }, "sha512-a/CbVmjuoO3E4JbUr2HOTsXndbcrdLWOM+ajbSQIY3gmLFzhjeXHGksGcp1NZ08pJjLZyTCxfz1C7v/ltJqycA=="],
+
+    "@slidev/theme-default": ["@slidev/theme-default@0.25.0", "", { "dependencies": { "@slidev/types": "^0.47.0", "codemirror-theme-vars": "^0.1.2", "prism-theme-vars": "^0.2.4" } }, "sha512-iWvthH1Ny+i6gTwRnEeeU+EiqsHC56UdEO45bqLSNmymRAOWkKUJ/M0o7iahLzHSXsiPu71B7C715WxqjXk2hw=="],
+
+    "@slidev/types": ["@slidev/types@0.47.5", "", {}, "sha512-X67V4cCgM0Sz50bP8GbVzmiL8DHC2IXvdKcsN7DlxHyf+/T4d9GveeGukwha5Fx3MuYeGZWKag7TFL2ZY4w54A=="],
+
+    "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-axis": ["@types/d3-axis@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw=="],
+
+    "@types/d3-brush": ["@types/d3-brush@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A=="],
+
+    "@types/d3-chord": ["@types/d3-chord@3.0.6", "", {}, "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-contour": ["@types/d3-contour@3.0.6", "", { "dependencies": { "@types/d3-array": "*", "@types/geojson": "*" } }, "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg=="],
+
+    "@types/d3-delaunay": ["@types/d3-delaunay@6.0.4", "", {}, "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="],
+
+    "@types/d3-dispatch": ["@types/d3-dispatch@3.0.7", "", {}, "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
+    "@types/d3-dsv": ["@types/d3-dsv@3.0.7", "", {}, "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-fetch": ["@types/d3-fetch@3.0.7", "", { "dependencies": { "@types/d3-dsv": "*" } }, "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA=="],
+
+    "@types/d3-force": ["@types/d3-force@3.0.10", "", {}, "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="],
+
+    "@types/d3-format": ["@types/d3-format@3.0.4", "", {}, "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g=="],
+
+    "@types/d3-geo": ["@types/d3-geo@3.1.0", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ=="],
+
+    "@types/d3-hierarchy": ["@types/d3-hierarchy@3.1.7", "", {}, "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-polygon": ["@types/d3-polygon@3.0.2", "", {}, "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA=="],
+
+    "@types/d3-quadtree": ["@types/d3-quadtree@3.0.6", "", {}, "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg=="],
+
+    "@types/d3-random": ["@types/d3-random@3.0.3", "", {}, "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-scale-chromatic": ["@types/d3-scale-chromatic@3.1.0", "", {}, "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-time-format": ["@types/d3-time-format@4.0.3", "", {}, "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
+    "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
+
+    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
+    "@types/linkify-it": ["@types/linkify-it@5.0.0", "", {}, "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q=="],
+
+    "@types/markdown-it": ["@types/markdown-it@14.1.2", "", { "dependencies": { "@types/linkify-it": "^5", "@types/mdurl": "^2" } }, "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog=="],
+
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/mdurl": ["@types/mdurl@2.0.0", "", {}, "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
+
+    "@types/node": ["@types/node@22.19.7", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw=="],
+
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@types/web-bluetooth": ["@types/web-bluetooth@0.0.21", "", {}, "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA=="],
+
+    "@typescript/ata": ["@typescript/ata@0.9.8", "", { "peerDependencies": { "typescript": ">=4.4.4" } }, "sha512-+M815CeDRJS5H5ciWfhFCKp25nNfF+LFWawWAaBhNlquFb2wS5IIMDI+2bKWN3GuU6mpj+FzySsOD29M4nG8Xg=="],
+
+    "@typescript/vfs": ["@typescript/vfs@1.6.2", "", { "dependencies": { "debug": "^4.1.1" }, "peerDependencies": { "typescript": "*" } }, "sha512-hoBwJwcbKHmvd2QVebiytN1aELvpk9B74B4L1mFm/XT1Q/VOYAWl2vQ9AWRFtQq8zmz6enTpfTV8WRc4ATjW/g=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
+
+    "@unhead/vue": ["@unhead/vue@2.1.2", "", { "dependencies": { "hookable": "^6.0.1", "unhead": "2.1.2" }, "peerDependencies": { "vue": ">=3.5.18" } }, "sha512-w5yxH/fkkLWAFAOnMSIbvAikNHYn6pgC7zGF/BasXf+K3CO1cYIPFehYAk5jpcsbiNPMc3goyyw1prGLoyD14g=="],
+
+    "@unocss/astro": ["@unocss/astro@66.6.0", "", { "dependencies": { "@unocss/core": "66.6.0", "@unocss/reset": "66.6.0", "@unocss/vite": "66.6.0" }, "peerDependencies": { "vite": "^2.9.0 || ^3.0.0-0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0 || ^8.0.0-0" }, "optionalPeers": ["vite"] }, "sha512-HCDgZnoXv6pZGUK9N4ko7ZeBP1YTIP8IFj0Vr7pXVdv9sGR9CofoueFbclTvPQ065UHSsG+WI+JO5z9/BGd5fw=="],
+
+    "@unocss/cli": ["@unocss/cli@66.6.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "@unocss/config": "66.6.0", "@unocss/core": "66.6.0", "@unocss/preset-wind3": "66.6.0", "@unocss/preset-wind4": "66.6.0", "@unocss/transformer-directives": "66.6.0", "cac": "^6.7.14", "chokidar": "^5.0.0", "colorette": "^2.0.20", "consola": "^3.4.2", "magic-string": "^0.30.21", "pathe": "^2.0.3", "perfect-debounce": "^2.0.0", "tinyglobby": "^0.2.15", "unplugin-utils": "^0.3.1" }, "bin": { "unocss": "bin/unocss.mjs" } }, "sha512-wtA6YBIvW2f8FISdYS8rx+B3ZGTUjw3YO3Fxz1ApUCHinYSdz8SoNWShH1I61LWbcjJ4hbjI/D9t/Dmgp6vmiQ=="],
+
+    "@unocss/config": ["@unocss/config@66.6.0", "", { "dependencies": { "@unocss/core": "66.6.0", "unconfig": "^7.4.2" } }, "sha512-YvNk/b9jGmT1TQGDbHR+0VALnTsPLzSTzw90t09ggny9YxeF0XnsP06M5+H0EJPwpmdigBC++KEIMaK8SYDsaQ=="],
+
+    "@unocss/core": ["@unocss/core@66.6.0", "", {}, "sha512-Sxm7HmhsPIIzxbPnWembPyobuCeA5j9KxL+jIOW2c+kZiTFjHeju7vuVWX9jmAMMC+UyDuuCQ4yE+kBo3Y7SWQ=="],
+
+    "@unocss/extractor-arbitrary-variants": ["@unocss/extractor-arbitrary-variants@66.6.0", "", { "dependencies": { "@unocss/core": "66.6.0" } }, "sha512-AsCmpbre4hQb+cKOf3gHUeYlF7guR/aCKZvw53VBk12qY5wNF7LdfIx4zWc5LFVCoRxIZlU2C7L4/Tt7AkiFMA=="],
+
+    "@unocss/extractor-mdc": ["@unocss/extractor-mdc@66.6.0", "", {}, "sha512-QnvoxHDWvTnuBFxYYLvVAMp1t4I7qFUcGdXXCLNUgmk5fU5IMccUDx2rXyy8lRIDXUjxW03AkaEP7YuaSMlT1g=="],
+
+    "@unocss/inspector": ["@unocss/inspector@66.6.0", "", { "dependencies": { "@unocss/core": "66.6.0", "@unocss/rule-utils": "66.6.0", "colorette": "^2.0.20", "gzip-size": "^6.0.0", "sirv": "^3.0.2", "vue-flow-layout": "^0.2.0" } }, "sha512-BvdY8ah+OTmzFMb+z8RZkaF15+PWRFt9S2bOARkkRBubybX9EE1rxM07l74kO5Dj16++CS4nO15XFq39pPoBvg=="],
+
+    "@unocss/postcss": ["@unocss/postcss@66.6.0", "", { "dependencies": { "@unocss/config": "66.6.0", "@unocss/core": "66.6.0", "@unocss/rule-utils": "66.6.0", "css-tree": "^3.1.0", "postcss": "^8.5.6", "tinyglobby": "^0.2.15" } }, "sha512-Tn8l8JMXJcTgzrPHSukpRBnVIt561bQCUle7jW8NXk61vYBy8p52nEBkNy5QMXybaCih5ghg2d/+nDIAl9YIpw=="],
+
+    "@unocss/preset-attributify": ["@unocss/preset-attributify@66.6.0", "", { "dependencies": { "@unocss/core": "66.6.0" } }, "sha512-IfGZT9LjQkfpJaVjDtFMxOlrEoj7m1DCztRdby0FaptXChE7vdgRkYFl8HDeXMkEIlzV1YTHuIarwJ+tV+1SRQ=="],
+
+    "@unocss/preset-icons": ["@unocss/preset-icons@66.6.0", "", { "dependencies": { "@iconify/utils": "^3.1.0", "@unocss/core": "66.6.0", "ofetch": "^1.5.1" } }, "sha512-ObgmN9SsqU7TiClNvy+mQDyqzwOhlBXT0whXFp3iiBfSbnxUIDyf4Pr/2hwxnAWrCWCQj7xw2H0Y0sDtXq8XkA=="],
+
+    "@unocss/preset-mini": ["@unocss/preset-mini@66.6.0", "", { "dependencies": { "@unocss/core": "66.6.0", "@unocss/extractor-arbitrary-variants": "66.6.0", "@unocss/rule-utils": "66.6.0" } }, "sha512-8bQyTuMJcry/z4JTDsQokI0187/1CJIkVx9hr9eEbKf/gWti538P8ktKEmHCf8IyT0At5dfP9oLHLCUzVetdbA=="],
+
+    "@unocss/preset-tagify": ["@unocss/preset-tagify@66.6.0", "", { "dependencies": { "@unocss/core": "66.6.0" } }, "sha512-Vy9olM61lqTDxcHbfDkIJNp9LF2m8K9I/F2J0diD+BVZgpym1QRK6+aZaeAPJuMCyQrOk87dm7VIiAPFtLOXFA=="],
+
+    "@unocss/preset-typography": ["@unocss/preset-typography@66.6.0", "", { "dependencies": { "@unocss/core": "66.6.0", "@unocss/rule-utils": "66.6.0" } }, "sha512-vDogO+jaatGSAoZqqa9+GJ18WbrwYzJr5UyIFUQqXJ5TUDaWzKb4Qhty2WnOtjQaf4sOMML8JFA/cydZl+Rjjw=="],
+
+    "@unocss/preset-uno": ["@unocss/preset-uno@66.6.0", "", { "dependencies": { "@unocss/core": "66.6.0", "@unocss/preset-wind3": "66.6.0" } }, "sha512-xDppgdgFk+JNrL9jhqhrn6H9IS8P10p1HSsWOYF+9owg43zqpeNpzDMvZGwq8uxq6guyB1fu6l4YzO+bDZnwvw=="],
+
+    "@unocss/preset-web-fonts": ["@unocss/preset-web-fonts@66.6.0", "", { "dependencies": { "@unocss/core": "66.6.0", "ofetch": "^1.5.1" } }, "sha512-Mqb8bVSAfDEnkGyAl8ZPdvaojq3YSow4lvxGCOm7nHJFIXkRKgYBgD3tmm+rvO81CUtihZd7hdw0Ay+8pYrlTw=="],
+
+    "@unocss/preset-wind": ["@unocss/preset-wind@66.6.0", "", { "dependencies": { "@unocss/core": "66.6.0", "@unocss/preset-wind3": "66.6.0" } }, "sha512-6uVq3/gV1MD9ZsycrYLP6OvAS9kI1oGAIuccKKspZHW3jqwEhJmPofDD4pYwbkx4i4zSWzoLakcfp9d67Szjqg=="],
+
+    "@unocss/preset-wind3": ["@unocss/preset-wind3@66.6.0", "", { "dependencies": { "@unocss/core": "66.6.0", "@unocss/preset-mini": "66.6.0", "@unocss/rule-utils": "66.6.0" } }, "sha512-7gzswF810BCSru7pF01BsMzGZbfrsWT5GV6JJLkhROS2pPjeNOpqy2VEfiavv5z09iGSIESeOFMlXr5ORuLZrg=="],
+
+    "@unocss/preset-wind4": ["@unocss/preset-wind4@66.6.0", "", { "dependencies": { "@unocss/core": "66.6.0", "@unocss/extractor-arbitrary-variants": "66.6.0", "@unocss/rule-utils": "66.6.0" } }, "sha512-1yyo9fmB+r5C92kSHU7lIaqGJdvz5UQyYZxYDxSmWLAUzWEK5HBRj6OkSF6rUnz+Yd4JvgOgACZNOShVOezPlA=="],
+
+    "@unocss/reset": ["@unocss/reset@66.6.0", "", {}, "sha512-OQK5F7Dzx0wWDSPTYEz7NRP9pekufSAkjxfKOyKokiXOUzVTg8Yx8sOvCsA3Oi0Rx5WlsO2LN+MOBekpkrttXg=="],
+
+    "@unocss/rule-utils": ["@unocss/rule-utils@66.6.0", "", { "dependencies": { "@unocss/core": "^66.6.0", "magic-string": "^0.30.21" } }, "sha512-v16l6p5VrefDx8P/gzWnp0p6/hCA0vZ4UMUN6SxHGVE6V+IBpX6I6Du3Egk9TdkhZ7o+Pe1NHxksHcjT0V/tww=="],
+
+    "@unocss/transformer-attributify-jsx": ["@unocss/transformer-attributify-jsx@66.6.0", "", { "dependencies": { "@babel/parser": "7.27.7", "@babel/traverse": "7.27.7", "@unocss/core": "66.6.0" } }, "sha512-fzjLVlhYO8JdHzIusRKAva5ZOnA4deOVYuiM6HVpbX7P19479TVHZgeSV+AG0BWLhmIJ2cer+n3/CIO5nodT6g=="],
+
+    "@unocss/transformer-compile-class": ["@unocss/transformer-compile-class@66.6.0", "", { "dependencies": { "@unocss/core": "66.6.0" } }, "sha512-OkwdbIfsbs8dtHIfBaoya/SPHZUJeogvJl2BpJb4/3nY/tWBZB/+i2vPMAML3D9aQYZAuC7uqcTRGNbuvyyy+w=="],
+
+    "@unocss/transformer-directives": ["@unocss/transformer-directives@66.6.0", "", { "dependencies": { "@unocss/core": "66.6.0", "@unocss/rule-utils": "66.6.0", "css-tree": "^3.1.0" } }, "sha512-2Z4FFjJI/bH6kKGuuuO0DpFEVSFOhFnGLTFK8y9BGz0cIOQOIuEKTemM7QLqPuyRSORBO1RKvcKvA3DV0n1X7g=="],
+
+    "@unocss/transformer-variant-group": ["@unocss/transformer-variant-group@66.6.0", "", { "dependencies": { "@unocss/core": "66.6.0" } }, "sha512-kWYYcrn8ZFKLVCU6kB8yaQY9iYgx3/XhPb9c0XZZ5QzWjoGffrl6XLUk8XrjR/yxC3qwHg/WizzsmsQ2OXF6Qg=="],
+
+    "@unocss/vite": ["@unocss/vite@66.6.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "@unocss/config": "66.6.0", "@unocss/core": "66.6.0", "@unocss/inspector": "66.6.0", "chokidar": "^5.0.0", "magic-string": "^0.30.21", "pathe": "^2.0.3", "tinyglobby": "^0.2.15", "unplugin-utils": "^0.3.1" }, "peerDependencies": { "vite": "^2.9.0 || ^3.0.0-0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0 || ^8.0.0-0" } }, "sha512-SC0/rX0xSjdu8Jaj98XztHOuvXHWDVk0YaHKRAQks2Oj3yyqAOrhzhDUH0zzFaQWf5bsKVYK40H+h4rMk9vm5Q=="],
+
+    "@vitejs/plugin-vue": ["@vitejs/plugin-vue@6.0.3", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-beta.53" }, "peerDependencies": { "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0", "vue": "^3.2.25" } }, "sha512-TlGPkLFLVOY3T7fZrwdvKpjprR3s4fxRln0ORDo1VQ7HHyxJwTlrjKU3kpVWTlaAjIEuCTokmjkZnr8Tpc925w=="],
+
+    "@vitejs/plugin-vue-jsx": ["@vitejs/plugin-vue-jsx@5.1.3", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/plugin-syntax-typescript": "^7.27.1", "@babel/plugin-transform-typescript": "^7.28.5", "@rolldown/pluginutils": "^1.0.0-beta.56", "@vue/babel-plugin-jsx": "^2.0.1" }, "peerDependencies": { "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0", "vue": "^3.0.0" } }, "sha512-I6Zr8cYVr5WHMW5gNOP09DNqW9rgO8RX73Wa6Czgq/0ndpTfJM4vfDChfOT1+3KtdrNqilNBtNlFwVeB02ZzGw=="],
+
+    "@vitest/expect": ["@vitest/expect@1.6.1", "", { "dependencies": { "@vitest/spy": "1.6.1", "@vitest/utils": "1.6.1", "chai": "^4.3.10" } }, "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog=="],
+
+    "@vitest/runner": ["@vitest/runner@1.6.1", "", { "dependencies": { "@vitest/utils": "1.6.1", "p-limit": "^5.0.0", "pathe": "^1.1.1" } }, "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@1.6.1", "", { "dependencies": { "magic-string": "^0.30.5", "pathe": "^1.1.1", "pretty-format": "^29.7.0" } }, "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ=="],
+
+    "@vitest/spy": ["@vitest/spy@1.6.1", "", { "dependencies": { "tinyspy": "^2.2.0" } }, "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw=="],
+
+    "@vitest/ui": ["@vitest/ui@1.6.1", "", { "dependencies": { "@vitest/utils": "1.6.1", "fast-glob": "^3.3.2", "fflate": "^0.8.1", "flatted": "^3.2.9", "pathe": "^1.1.1", "picocolors": "^1.0.0", "sirv": "^2.0.4" }, "peerDependencies": { "vitest": "1.6.1" } }, "sha512-xa57bCPGuzEFqGjPs3vVLyqareG8DX0uMkr5U/v5vLv5/ZUrBrPL7gzxzTJedEyZxFMfsozwTIbbYfEQVo3kgg=="],
+
+    "@vitest/utils": ["@vitest/utils@1.6.1", "", { "dependencies": { "diff-sequences": "^29.6.3", "estree-walker": "^3.0.3", "loupe": "^2.3.7", "pretty-format": "^29.7.0" } }, "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g=="],
+
+    "@volar/language-core": ["@volar/language-core@2.4.27", "", { "dependencies": { "@volar/source-map": "2.4.27" } }, "sha512-DjmjBWZ4tJKxfNC1F6HyYERNHPYS7L7OPFyCrestykNdUZMFYzI9WTyvwPcaNaHlrEUwESHYsfEw3isInncZxQ=="],
+
+    "@volar/source-map": ["@volar/source-map@2.4.27", "", {}, "sha512-ynlcBReMgOZj2i6po+qVswtDUeeBRCTgDurjMGShbm8WYZgJ0PA4RmtebBJ0BCYol1qPv3GQF6jK7C9qoVc7lg=="],
+
+    "@vue/babel-helper-vue-transform-on": ["@vue/babel-helper-vue-transform-on@2.0.1", "", {}, "sha512-uZ66EaFbnnZSYqYEyplWvn46GhZ1KuYSThdT68p+am7MgBNbQ3hphTL9L+xSIsWkdktwhPYLwPgVWqo96jDdRA=="],
+
+    "@vue/babel-plugin-jsx": ["@vue/babel-plugin-jsx@2.0.1", "", { "dependencies": { "@babel/helper-module-imports": "^7.27.1", "@babel/helper-plugin-utils": "^7.27.1", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.4", "@babel/types": "^7.28.4", "@vue/babel-helper-vue-transform-on": "2.0.1", "@vue/babel-plugin-resolve-type": "2.0.1", "@vue/shared": "^3.5.22" }, "peerDependencies": { "@babel/core": "^7.0.0-0" }, "optionalPeers": ["@babel/core"] }, "sha512-a8CaLQjD/s4PVdhrLD/zT574ZNPnZBOY+IhdtKWRB4HRZ0I2tXBi5ne7d9eCfaYwp5gU5+4KIyFTV1W1YL9xZA=="],
+
+    "@vue/babel-plugin-resolve-type": ["@vue/babel-plugin-resolve-type@2.0.1", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/helper-module-imports": "^7.27.1", "@babel/helper-plugin-utils": "^7.27.1", "@babel/parser": "^7.28.4", "@vue/compiler-sfc": "^3.5.22" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-ybwgIuRGRRBhOU37GImDoWQoz+TlSqap65qVI6iwg/J7FfLTLmMf97TS7xQH9I7Qtr/gp161kYVdhr1ZMraSYQ=="],
+
+    "@vue/compiler-core": ["@vue/compiler-core@3.5.27", "", { "dependencies": { "@babel/parser": "^7.28.5", "@vue/shared": "3.5.27", "entities": "^7.0.0", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-gnSBQjZA+//qDZen+6a2EdHqJ68Z7uybrMf3SPjEGgG4dicklwDVmMC1AeIHxtLVPT7sn6sH1KOO+tS6gwOUeQ=="],
+
+    "@vue/compiler-dom": ["@vue/compiler-dom@3.5.27", "", { "dependencies": { "@vue/compiler-core": "3.5.27", "@vue/shared": "3.5.27" } }, "sha512-oAFea8dZgCtVVVTEC7fv3T5CbZW9BxpFzGGxC79xakTr6ooeEqmRuvQydIiDAkglZEAd09LgVf1RoDnL54fu5w=="],
+
+    "@vue/compiler-sfc": ["@vue/compiler-sfc@3.5.27", "", { "dependencies": { "@babel/parser": "^7.28.5", "@vue/compiler-core": "3.5.27", "@vue/compiler-dom": "3.5.27", "@vue/compiler-ssr": "3.5.27", "@vue/shared": "3.5.27", "estree-walker": "^2.0.2", "magic-string": "^0.30.21", "postcss": "^8.5.6", "source-map-js": "^1.2.1" } }, "sha512-sHZu9QyDPeDmN/MRoshhggVOWE5WlGFStKFwu8G52swATgSny27hJRWteKDSUUzUH+wp+bmeNbhJnEAel/auUQ=="],
+
+    "@vue/compiler-ssr": ["@vue/compiler-ssr@3.5.27", "", { "dependencies": { "@vue/compiler-dom": "3.5.27", "@vue/shared": "3.5.27" } }, "sha512-Sj7h+JHt512fV1cTxKlYhg7qxBvack+BGncSpH+8vnN+KN95iPIcqB5rsbblX40XorP+ilO7VIKlkuu3Xq2vjw=="],
+
+    "@vue/devtools-api": ["@vue/devtools-api@6.6.4", "", {}, "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g=="],
+
+    "@vue/language-core": ["@vue/language-core@3.2.4", "", { "dependencies": { "@volar/language-core": "2.4.27", "@vue/compiler-dom": "^3.5.0", "@vue/shared": "^3.5.0", "alien-signals": "^3.0.0", "muggle-string": "^0.4.1", "path-browserify": "^1.0.1", "picomatch": "^4.0.2" } }, "sha512-bqBGuSG4KZM45KKTXzGtoCl9cWju5jsaBKaJJe3h5hRAAWpZUuj5G+L+eI01sPIkm4H6setKRlw7E85wLdDNew=="],
+
+    "@vue/reactivity": ["@vue/reactivity@3.5.27", "", { "dependencies": { "@vue/shared": "3.5.27" } }, "sha512-vvorxn2KXfJ0nBEnj4GYshSgsyMNFnIQah/wczXlsNXt+ijhugmW+PpJ2cNPe4V6jpnBcs0MhCODKllWG+nvoQ=="],
+
+    "@vue/runtime-core": ["@vue/runtime-core@3.5.27", "", { "dependencies": { "@vue/reactivity": "3.5.27", "@vue/shared": "3.5.27" } }, "sha512-fxVuX/fzgzeMPn/CLQecWeDIFNt3gQVhxM0rW02Tvp/YmZfXQgcTXlakq7IMutuZ/+Ogbn+K0oct9J3JZfyk3A=="],
+
+    "@vue/runtime-dom": ["@vue/runtime-dom@3.5.27", "", { "dependencies": { "@vue/reactivity": "3.5.27", "@vue/runtime-core": "3.5.27", "@vue/shared": "3.5.27", "csstype": "^3.2.3" } }, "sha512-/QnLslQgYqSJ5aUmb5F0z0caZPGHRB8LEAQ1s81vHFM5CBfnun63rxhvE/scVb/j3TbBuoZwkJyiLCkBluMpeg=="],
+
+    "@vue/server-renderer": ["@vue/server-renderer@3.5.27", "", { "dependencies": { "@vue/compiler-ssr": "3.5.27", "@vue/shared": "3.5.27" }, "peerDependencies": { "vue": "3.5.27" } }, "sha512-qOz/5thjeP1vAFc4+BY3Nr6wxyLhpeQgAE/8dDtKo6a6xdk+L4W46HDZgNmLOBUDEkFXV3G7pRiUqxjX0/2zWA=="],
+
+    "@vue/shared": ["@vue/shared@3.5.27", "", {}, "sha512-dXr/3CgqXsJkZ0n9F3I4elY8wM9jMJpP3pvRG52r6m0tu/MsAFIe6JpXVGeNMd/D9F4hQynWT8Rfuj0bdm9kFQ=="],
+
+    "@vueuse/core": ["@vueuse/core@14.1.0", "", { "dependencies": { "@types/web-bluetooth": "^0.0.21", "@vueuse/metadata": "14.1.0", "@vueuse/shared": "14.1.0" }, "peerDependencies": { "vue": "^3.5.0" } }, "sha512-rgBinKs07hAYyPF834mDTigH7BtPqvZ3Pryuzt1SD/lg5wEcWqvwzXXYGEDb2/cP0Sj5zSvHl3WkmMELr5kfWw=="],
+
+    "@vueuse/math": ["@vueuse/math@14.1.0", "", { "dependencies": { "@vueuse/shared": "14.1.0" }, "peerDependencies": { "vue": "^3.5.0" } }, "sha512-33AgrhdJLkQe1BgQKGcaxmtJ8xnegfIk9R7/ysZrzMy/g+FFts6fKCgNmXoFRFICviL2aBDfyEfmdgWIuxRlPw=="],
+
+    "@vueuse/metadata": ["@vueuse/metadata@14.1.0", "", {}, "sha512-7hK4g015rWn2PhKcZ99NyT+ZD9sbwm7SGvp7k+k+rKGWnLjS/oQozoIZzWfCewSUeBmnJkIb+CNr7Zc/EyRnnA=="],
+
+    "@vueuse/motion": ["@vueuse/motion@3.0.3", "", { "dependencies": { "@vueuse/core": "^13.0.0", "@vueuse/shared": "^13.0.0", "defu": "^6.1.4", "framesync": "^6.1.2", "popmotion": "^11.0.5", "style-value-types": "^5.1.2" }, "optionalDependencies": { "@nuxt/kit": "^3.13.0" }, "peerDependencies": { "vue": ">=3.0.0" } }, "sha512-4B+ITsxCI9cojikvrpaJcLXyq0spj3sdlzXjzesWdMRd99hhtFI6OJ/1JsqwtF73YooLe0hUn/xDR6qCtmn5GQ=="],
+
+    "@vueuse/shared": ["@vueuse/shared@14.1.0", "", { "peerDependencies": { "vue": "^3.5.0" } }, "sha512-EcKxtYvn6gx1F8z9J5/rsg3+lTQnvOruQd8fUecW99DCK04BkWD7z5KQ/wTAx+DazyoEE9dJt/zV8OIEQbM6kw=="],
+
+    "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
+
+    "acorn-walk": ["acorn-walk@8.3.4", "", { "dependencies": { "acorn": "^8.11.0" } }, "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "alien-signals": ["alien-signals@3.1.2", "", {}, "sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "ansis": ["ansis@4.2.0", "", {}, "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig=="],
+
+    "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "assertion-error": ["assertion-error@1.1.0", "", {}, "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.9.19", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg=="],
+
+    "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
+
+    "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
+
+    "birpc": ["birpc@2.9.0", "", {}, "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
+
+    "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
+
+    "c12": ["c12@3.3.3", "", { "dependencies": { "chokidar": "^5.0.0", "confbox": "^0.2.2", "defu": "^6.1.4", "dotenv": "^17.2.3", "exsolve": "^1.0.8", "giget": "^2.0.0", "jiti": "^2.6.1", "ohash": "^2.0.11", "pathe": "^2.0.3", "perfect-debounce": "^2.0.0", "pkg-types": "^2.3.0", "rc9": "^2.1.2" }, "peerDependencies": { "magicast": "*" }, "optionalPeers": ["magicast"] }, "sha512-750hTRvgBy5kcMNPdh95Qo+XUBeGo8C7nsKSmedDmaQI+E0r82DwHeM6vBewDe4rGFbnxoa4V9pw+sPh5+Iz8Q=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001766", "", {}, "sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA=="],
+
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
+    "chai": ["chai@4.5.0", "", { "dependencies": { "assertion-error": "^1.1.0", "check-error": "^1.0.3", "deep-eql": "^4.1.3", "get-func-name": "^2.0.2", "loupe": "^2.3.6", "pathval": "^1.1.1", "type-detect": "^4.1.0" } }, "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw=="],
+
+    "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+
+    "check-error": ["check-error@1.0.3", "", { "dependencies": { "get-func-name": "^2.0.2" } }, "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg=="],
+
+    "chevrotain": ["chevrotain@11.0.3", "", { "dependencies": { "@chevrotain/cst-dts-gen": "11.0.3", "@chevrotain/gast": "11.0.3", "@chevrotain/regexp-to-ast": "11.0.3", "@chevrotain/types": "11.0.3", "@chevrotain/utils": "11.0.3", "lodash-es": "4.17.21" } }, "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw=="],
+
+    "chevrotain-allstar": ["chevrotain-allstar@0.3.1", "", { "dependencies": { "lodash-es": "^4.17.21" }, "peerDependencies": { "chevrotain": "^11.0.0" } }, "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw=="],
+
+    "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
+    "citty": ["citty@0.1.6", "", { "dependencies": { "consola": "^3.2.3" } }, "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ=="],
+
+    "cli-progress": ["cli-progress@3.12.0", "", { "dependencies": { "string-width": "^4.2.3" } }, "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A=="],
+
+    "cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
+
+    "clone-regexp": ["clone-regexp@3.0.0", "", { "dependencies": { "is-regexp": "^3.0.0" } }, "sha512-ujdnoq2Kxb8s3ItNBtnYeXdm07FcU0u8ARAT1lQ2YdMwQC+cdiXX8KoqMVuglztILivceTtp4ivqGSmEmhBUJw=="],
+
+    "codemirror-theme-vars": ["codemirror-theme-vars@0.1.2", "", {}, "sha512-WTau8X2q58b0SOAY9DO+iQVw8JKVEgyQIqArp2D732tcc+pobbMta3bnVMdQdmgwuvNrOFFr6HoxPRoQOgooFA=="],
+
+    "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
+
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
+
+    "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
+
+    "confbox": ["confbox@0.2.2", "", {}, "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ=="],
+
+    "connect": ["connect@3.7.0", "", { "dependencies": { "debug": "2.6.9", "finalhandler": "1.1.2", "parseurl": "~1.3.3", "utils-merge": "1.0.1" } }, "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ=="],
+
+    "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
+
+    "convert-hrtime": ["convert-hrtime@5.0.0", "", {}, "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
+
+    "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "css-tree": ["css-tree@2.3.1", "", { "dependencies": { "mdn-data": "2.0.30", "source-map-js": "^1.0.1" } }, "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw=="],
+
+    "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
+
+    "cssstyle": ["cssstyle@4.6.0", "", { "dependencies": { "@asamuzakjp/css-color": "^3.2.0", "rrweb-cssom": "^0.8.0" } }, "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "cytoscape": ["cytoscape@3.33.1", "", {}, "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ=="],
+
+    "cytoscape-cose-bilkent": ["cytoscape-cose-bilkent@4.1.0", "", { "dependencies": { "cose-base": "^1.0.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ=="],
+
+    "cytoscape-fcose": ["cytoscape-fcose@2.2.0", "", { "dependencies": { "cose-base": "^2.2.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ=="],
+
+    "d3": ["d3@7.9.0", "", { "dependencies": { "d3-array": "3", "d3-axis": "3", "d3-brush": "3", "d3-chord": "3", "d3-color": "3", "d3-contour": "4", "d3-delaunay": "6", "d3-dispatch": "3", "d3-drag": "3", "d3-dsv": "3", "d3-ease": "3", "d3-fetch": "3", "d3-force": "3", "d3-format": "3", "d3-geo": "3", "d3-hierarchy": "3", "d3-interpolate": "3", "d3-path": "3", "d3-polygon": "3", "d3-quadtree": "3", "d3-random": "3", "d3-scale": "4", "d3-scale-chromatic": "3", "d3-selection": "3", "d3-shape": "3", "d3-time": "3", "d3-time-format": "4", "d3-timer": "3", "d3-transition": "3", "d3-zoom": "3" } }, "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA=="],
+
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-axis": ["d3-axis@3.0.0", "", {}, "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="],
+
+    "d3-brush": ["d3-brush@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "3", "d3-transition": "3" } }, "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ=="],
+
+    "d3-chord": ["d3-chord@3.0.1", "", { "dependencies": { "d3-path": "1 - 3" } }, "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-contour": ["d3-contour@4.0.2", "", { "dependencies": { "d3-array": "^3.2.0" } }, "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA=="],
+
+    "d3-delaunay": ["d3-delaunay@6.0.4", "", { "dependencies": { "delaunator": "5" } }, "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-dsv": ["d3-dsv@3.0.1", "", { "dependencies": { "commander": "7", "iconv-lite": "0.6", "rw": "1" }, "bin": { "csv2json": "bin/dsv2json.js", "csv2tsv": "bin/dsv2dsv.js", "dsv2dsv": "bin/dsv2dsv.js", "dsv2json": "bin/dsv2json.js", "json2csv": "bin/json2dsv.js", "json2dsv": "bin/json2dsv.js", "json2tsv": "bin/json2dsv.js", "tsv2csv": "bin/dsv2dsv.js", "tsv2json": "bin/dsv2json.js" } }, "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-fetch": ["d3-fetch@3.0.1", "", { "dependencies": { "d3-dsv": "1 - 3" } }, "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw=="],
+
+    "d3-force": ["d3-force@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-geo": ["d3-geo@3.1.1", "", { "dependencies": { "d3-array": "2.5.0 - 3" } }, "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q=="],
+
+    "d3-hierarchy": ["d3-hierarchy@3.1.2", "", {}, "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-polygon": ["d3-polygon@3.0.1", "", {}, "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-random": ["d3-random@3.0.1", "", {}, "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="],
+
+    "d3-sankey": ["d3-sankey@0.12.3", "", { "dependencies": { "d3-array": "1 - 2", "d3-shape": "^1.2.0" } }, "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
+    "dagre-d3-es": ["dagre-d3-es@7.0.13", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q=="],
+
+    "data-urls": ["data-urls@5.0.0", "", { "dependencies": { "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0" } }, "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg=="],
+
+    "dayjs": ["dayjs@1.11.19", "", {}, "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
+    "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
+
+    "deep-eql": ["deep-eql@4.1.4", "", { "dependencies": { "type-detect": "^4.0.0" } }, "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg=="],
+
+    "default-browser": ["default-browser@5.4.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-XDuvSq38Hr1MdN47EDvYtx3U0MTqpCEn+F6ft8z2vYDzMrvQhVp0ui9oQdqW3MvK3vqUETglt1tVGgjLuJ5izg=="],
+
+    "default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
+
+    "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
+
+    "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
+
+    "delaunator": ["delaunator@5.0.1", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "destr": ["destr@2.0.5", "", {}, "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
+
+    "diff-match-patch-es": ["diff-match-patch-es@1.0.1", "", {}, "sha512-KhSofrZDERg/NE6Nd+TK53knp2qz0o2Ix8rhkXd3Chfm7Wlo58Eq/juNmkyS6bS+3xS26L3Pstz3BdY/q+e9UQ=="],
+
+    "diff-sequences": ["diff-sequences@29.6.3", "", {}, "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q=="],
+
+    "dns-packet": ["dns-packet@5.6.1", "", { "dependencies": { "@leichtgewicht/ip-codec": "^2.0.1" } }, "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw=="],
+
+    "dns-socket": ["dns-socket@4.2.2", "", { "dependencies": { "dns-packet": "^5.2.4" } }, "sha512-BDeBd8najI4/lS00HSKpdFia+OvUMytaVjfzR9n5Lq8MlZRSvtbI+uLtx1+XmQFls5wFU9dssccTmQQ6nfpjdg=="],
+
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "dompurify": ["dompurify@3.2.7", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
+    "dotenv": ["dotenv@17.2.3", "", {}, "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w=="],
+
+    "drauu": ["drauu@1.0.0", "", { "dependencies": { "@drauu/core": "1.0.0" } }, "sha512-K3a1cbP2l4i0H/bmNM4nyGsY5/hiH5a10sEHlksqKue0+TPQCHrV9DwPad+St06CJwpkdzVJ/FyOYTIAm82rgg=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "duplexer": ["duplexer@0.1.2", "", {}, "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "electron-to-chromium": ["electron-to-chromium@1.5.283", "", {}, "sha512-3vifjt1HgrGW/h76UEeny+adYApveS9dH2h3p57JYzBSXJIKUJAvtmIytDKjcSCt9xHfrNCFJ7gts6vkhuq++w=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "encodeurl": ["encodeurl@1.0.2", "", {}, "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="],
+
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
+
+    "errx": ["errx@0.1.0", "", {}, "sha512-fZmsRiDNv07K6s2KkKFTiD2aIvECa7++PKyD5NC32tpRw46qZA3sOz+aM+/V9V0GDHxVTKLziveV4JhzBHDp9Q=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
+    "esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.2", "@esbuild/android-arm": "0.27.2", "@esbuild/android-arm64": "0.27.2", "@esbuild/android-x64": "0.27.2", "@esbuild/darwin-arm64": "0.27.2", "@esbuild/darwin-x64": "0.27.2", "@esbuild/freebsd-arm64": "0.27.2", "@esbuild/freebsd-x64": "0.27.2", "@esbuild/linux-arm": "0.27.2", "@esbuild/linux-arm64": "0.27.2", "@esbuild/linux-ia32": "0.27.2", "@esbuild/linux-loong64": "0.27.2", "@esbuild/linux-mips64el": "0.27.2", "@esbuild/linux-ppc64": "0.27.2", "@esbuild/linux-riscv64": "0.27.2", "@esbuild/linux-s390x": "0.27.2", "@esbuild/linux-x64": "0.27.2", "@esbuild/netbsd-arm64": "0.27.2", "@esbuild/netbsd-x64": "0.27.2", "@esbuild/openbsd-arm64": "0.27.2", "@esbuild/openbsd-x64": "0.27.2", "@esbuild/openharmony-arm64": "0.27.2", "@esbuild/sunos-x64": "0.27.2", "@esbuild/win32-arm64": "0.27.2", "@esbuild/win32-ia32": "0.27.2", "@esbuild/win32-x64": "0.27.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
+    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "execa": ["execa@8.0.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^8.0.1", "human-signals": "^5.0.0", "is-stream": "^3.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^5.1.0", "onetime": "^6.0.0", "signal-exit": "^4.1.0", "strip-final-newline": "^3.0.0" } }, "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg=="],
+
+    "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
+
+    "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
+
+    "file-saver": ["file-saver@2.0.5", "", {}, "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "finalhandler": ["finalhandler@1.1.2", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~1.0.2", "escape-html": "~1.0.3", "on-finished": "~2.3.0", "parseurl": "~1.3.3", "statuses": "~1.5.0", "unpipe": "~1.0.0" } }, "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA=="],
+
+    "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
+
+    "floating-vue": ["floating-vue@5.2.2", "", { "dependencies": { "@floating-ui/dom": "~1.1.1", "vue-resize": "^2.0.0-alpha.1" }, "peerDependencies": { "@nuxt/kit": "^3.2.0", "vue": "^3.2.0" }, "optionalPeers": ["@nuxt/kit"] }, "sha512-afW+h2CFafo+7Y9Lvw/xsqjaQlKLdJV7h1fCHfcYQ1C4SVMlu7OAekqWgu5d4SgvkBVU0pVpLlVsrSTBURFRkg=="],
+
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
+    "framesync": ["framesync@6.1.2", "", { "dependencies": { "tslib": "2.4.0" } }, "sha512-jBTqhX6KaQVDyus8muwZbBeGGP0XgujBRbQ7gM7BRdS3CadCZIHiawyzYLnafYcvZIh5j8WE7cxZKFn7dXhu9g=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "function-timeout": ["function-timeout@0.1.1", "", {}, "sha512-0NVVC0TaP7dSTvn1yMiy6d6Q8gifzbvQafO46RtLG/kHJUBNd+pVRGOBoK44wNBvtSPUJRfdVvkFdD3p0xvyZg=="],
+
+    "fuse.js": ["fuse.js@7.1.0", "", {}, "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ=="],
+
+    "fzf": ["fzf@0.5.2", "", {}, "sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q=="],
+
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
+
+    "get-func-name": ["get-func-name@2.0.2", "", {}, "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-port-please": ["get-port-please@3.2.0", "", {}, "sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "get-stream": ["get-stream@8.0.1", "", {}, "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA=="],
+
+    "giget": ["giget@2.0.0", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.0", "defu": "^6.1.4", "node-fetch-native": "^1.6.6", "nypm": "^0.6.0", "pathe": "^2.0.3" }, "bin": { "giget": "dist/cli.mjs" } }, "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA=="],
+
+    "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "global-directory": ["global-directory@4.0.1", "", { "dependencies": { "ini": "4.1.1" } }, "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q=="],
+
+    "globals": ["globals@11.12.0", "", {}, "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "gray-matter": ["gray-matter@4.0.3", "", { "dependencies": { "js-yaml": "^3.13.1", "kind-of": "^6.0.2", "section-matter": "^1.0.0", "strip-bom-string": "^1.0.0" } }, "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q=="],
+
+    "gzip-size": ["gzip-size@6.0.0", "", { "dependencies": { "duplexer": "^0.1.2" } }, "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q=="],
+
+    "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
+    "hey-listen": ["hey-listen@1.0.8", "", {}, "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="],
+
+    "hookable": ["hookable@6.0.1", "", {}, "sha512-uKGyY8BuzN/a5gvzvA+3FVWo0+wUjgtfSdnmjtrOVwQCZPHpHDH2WRO3VZSOeluYrHoDCiXFffZXs8Dj1ULWtw=="],
+
+    "html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
+
+    "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https": ["https@1.0.0", "", {}, "sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "human-signals": ["human-signals@5.0.0", "", {}, "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "image-size": ["image-size@1.2.1", "", { "dependencies": { "queue": "6.0.2" }, "bin": { "image-size": "bin/image-size.js" } }, "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw=="],
+
+    "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ini": ["ini@4.1.1", "", {}, "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g=="],
+
+    "internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
+
+    "ip-regex": ["ip-regex@5.0.0", "", {}, "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw=="],
+
+    "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
+
+    "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+
+    "is-extendable": ["is-extendable@0.1.1", "", {}, "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-in-ssh": ["is-in-ssh@1.0.0", "", {}, "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw=="],
+
+    "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
+
+    "is-installed-globally": ["is-installed-globally@1.0.0", "", { "dependencies": { "global-directory": "^4.0.1", "is-path-inside": "^4.0.0" } }, "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ=="],
+
+    "is-ip": ["is-ip@5.0.1", "", { "dependencies": { "ip-regex": "^5.0.0", "super-regex": "^0.2.0" } }, "sha512-FCsGHdlrOnZQcp0+XT5a+pYowf33itBalCl+7ovNXC/7o5BhIpG14M3OrpPPdBSIQJCm+0M5+9mO7S9VVTTCFw=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "is-path-inside": ["is-path-inside@4.0.0", "", {}, "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA=="],
+
+    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
+    "is-regexp": ["is-regexp@3.1.0", "", {}, "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA=="],
+
+    "is-stream": ["is-stream@3.0.0", "", {}, "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="],
+
+    "is-wsl": ["is-wsl@3.1.0", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw=="],
+
+    "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+
+    "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
+
+    "js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
+
+    "jsdom": ["jsdom@23.2.0", "", { "dependencies": { "@asamuzakjp/dom-selector": "^2.0.1", "cssstyle": "^4.0.1", "data-urls": "^5.0.0", "decimal.js": "^10.4.3", "form-data": "^4.0.0", "html-encoding-sniffer": "^4.0.0", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.2", "is-potential-custom-element-name": "^1.0.1", "parse5": "^7.1.2", "rrweb-cssom": "^0.6.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^4.1.3", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^7.0.0", "whatwg-encoding": "^3.1.1", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0", "ws": "^8.16.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^2.11.2" }, "optionalPeers": ["canvas"] }, "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "jszip": ["jszip@3.10.1", "", { "dependencies": { "lie": "~3.3.0", "pako": "~1.0.2", "readable-stream": "~2.3.6", "setimmediate": "^1.0.5" } }, "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g=="],
+
+    "katex": ["katex@0.16.28", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-YHzO7721WbmAL6Ov1uzN/l5mY5WWWhJBSW+jq4tkfZfsxmo1hu6frS0EOswvjBUnWE6NtjEs48SFn5CQESRLZg=="],
+
+    "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
+
+    "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
+
+    "kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
+
+    "klona": ["klona@2.0.6", "", {}, "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA=="],
+
+    "knitwork": ["knitwork@1.3.0", "", {}, "sha512-4LqMNoONzR43B1W0ek0fhXMsDNW/zxa1NdFAVMY+k28pgZLovR4G3PB5MrpTxCy1QaZCqNoiaKPr5w5qZHfSNw=="],
+
+    "langium": ["langium@3.3.1", "", { "dependencies": { "chevrotain": "~11.0.3", "chevrotain-allstar": "~0.3.0", "vscode-languageserver": "~9.0.1", "vscode-languageserver-textdocument": "~1.0.11", "vscode-uri": "~3.0.8" } }, "sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w=="],
+
+    "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
+
+    "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
+
+    "linkify-it": ["linkify-it@5.0.0", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ=="],
+
+    "local-pkg": ["local-pkg@1.1.2", "", { "dependencies": { "mlly": "^1.7.4", "pkg-types": "^2.3.0", "quansync": "^0.2.11" } }, "sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A=="],
+
+    "lodash-es": ["lodash-es@4.17.23", "", {}, "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="],
+
+    "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
+    "loupe": ["loupe@2.3.7", "", { "dependencies": { "get-func-name": "^2.0.1" } }, "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA=="],
+
+    "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "magic-string-stack": ["magic-string-stack@1.1.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "magic-string": "^0.30.17" } }, "sha512-eAjQQ16Woyi71/6gQoLvn9Mte0JDoS5zUV/BMk0Pzs8Fou+nEuo5T0UbLWBhm3mXiK2YnFz2lFpEEVcLcohhVw=="],
+
+    "markdown-it": ["markdown-it@14.1.0", "", { "dependencies": { "argparse": "^2.0.1", "entities": "^4.4.0", "linkify-it": "^5.0.0", "mdurl": "^2.0.0", "punycode.js": "^2.3.1", "uc.micro": "^2.1.0" }, "bin": { "markdown-it": "bin/markdown-it.mjs" } }, "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg=="],
+
+    "markdown-it-async": ["markdown-it-async@2.2.0", "", { "dependencies": { "@types/markdown-it": "^14.1.2", "markdown-it": "^14.1.0" } }, "sha512-sITME+kf799vMeO/ww/CjH6q+c05f6TLpn6VOmmWCGNqPJzSh+uFgZoMB9s0plNtW6afy63qglNAC3MhrhP/gg=="],
+
+    "markdown-it-footnote": ["markdown-it-footnote@4.0.0", "", {}, "sha512-WYJ7urf+khJYl3DqofQpYfEYkZKbmXmwxQV8c8mO/hGIhgZ1wOe7R4HLFNwqx7TjILbnC98fuyeSsin19JdFcQ=="],
+
+    "markdown-it-mdc": ["markdown-it-mdc@0.2.8", "", { "dependencies": { "yaml": "^2.8.2" }, "peerDependencies": { "@types/markdown-it": "*", "markdown-it": "^14.0.0" } }, "sha512-d1cVHZ2rdpjJWSYSVZG9Q0zXXCL3BobGjFyLKHv5sOn4Uw+W7Xy5idKTrJBWizyZ/qa/IAxYcj0k/iYhCs334g=="],
+
+    "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
+    "marked": ["marked@14.0.0", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
+
+    "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA=="],
+
+    "mdast-util-gfm": ["mdast-util-gfm@3.1.0", "", { "dependencies": { "mdast-util-from-markdown": "^2.0.0", "mdast-util-gfm-autolink-literal": "^2.0.0", "mdast-util-gfm-footnote": "^2.0.0", "mdast-util-gfm-strikethrough": "^2.0.0", "mdast-util-gfm-table": "^2.0.0", "mdast-util-gfm-task-list-item": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ=="],
+
+    "mdast-util-gfm-autolink-literal": ["mdast-util-gfm-autolink-literal@2.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "ccount": "^2.0.0", "devlop": "^1.0.0", "mdast-util-find-and-replace": "^3.0.0", "micromark-util-character": "^2.0.0" } }, "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ=="],
+
+    "mdast-util-gfm-footnote": ["mdast-util-gfm-footnote@2.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0" } }, "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ=="],
+
+    "mdast-util-gfm-strikethrough": ["mdast-util-gfm-strikethrough@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg=="],
+
+    "mdast-util-gfm-table": ["mdast-util-gfm-table@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "markdown-table": "^3.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg=="],
+
+    "mdast-util-gfm-task-list-item": ["mdast-util-gfm-task-list-item@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ=="],
+
+    "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
+
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
+    "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
+
+    "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
+
+    "mdn-data": ["mdn-data@2.0.30", "", {}, "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="],
+
+    "mdurl": ["mdurl@2.0.0", "", {}, "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="],
+
+    "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
+
+    "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "mermaid": ["mermaid@11.12.2", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.1", "@iconify/utils": "^3.0.1", "@mermaid-js/parser": "^0.6.3", "@types/d3": "^7.4.3", "cytoscape": "^3.29.3", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.13", "dayjs": "^1.11.18", "dompurify": "^3.2.5", "katex": "^0.16.22", "khroma": "^2.1.0", "lodash-es": "^4.17.21", "marked": "^16.2.1", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0" } }, "sha512-n34QPDPEKmaeCG4WDMGy0OT6PSyxKCfy2pJgShP+Qow2KLrvWjclwbc3yXfSIf4BanqWEhQEpngWwNp/XhZt6w=="],
+
+    "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
+
+    "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
+
+    "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
+
+    "micromark-factory-label": ["micromark-factory-label@2.0.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg=="],
+
+    "micromark-factory-space": ["micromark-factory-space@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg=="],
+
+    "micromark-factory-title": ["micromark-factory-title@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw=="],
+
+    "micromark-factory-whitespace": ["micromark-factory-whitespace@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-chunked": ["micromark-util-chunked@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA=="],
+
+    "micromark-util-classify-character": ["micromark-util-classify-character@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q=="],
+
+    "micromark-util-combine-extensions": ["micromark-util-combine-extensions@2.0.1", "", { "dependencies": { "micromark-util-chunked": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg=="],
+
+    "micromark-util-decode-numeric-character-reference": ["micromark-util-decode-numeric-character-reference@2.0.2", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw=="],
+
+    "micromark-util-decode-string": ["micromark-util-decode-string@2.0.1", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-html-tag-name": ["micromark-util-html-tag-name@2.0.1", "", {}, "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="],
+
+    "micromark-util-normalize-identifier": ["micromark-util-normalize-identifier@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q=="],
+
+    "micromark-util-resolve-all": ["micromark-util-resolve-all@2.0.1", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-subtokenize": ["micromark-util-subtokenize@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
+
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "mimic-fn": ["mimic-fn@4.0.0", "", {}, "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw=="],
+
+    "mlly": ["mlly@1.8.0", "", { "dependencies": { "acorn": "^8.15.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.1" } }, "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g=="],
+
+    "monaco-editor": ["monaco-editor@0.55.1", "", { "dependencies": { "dompurify": "3.2.7", "marked": "14.0.0" } }, "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A=="],
+
+    "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "muggle-string": ["muggle-string@0.4.1", "", {}, "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "nanotar": ["nanotar@0.2.0", "", {}, "sha512-9ca1h0Xjvo9bEkE4UOxgAzLV0jHKe6LMaxo37ND2DAhhAtd0j8pR1Wxz+/goMrZO8AEZTWCmyaOsFI/W5AdpCQ=="],
+
+    "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
+
+    "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
+
+    "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
+
+    "npm-run-path": ["npm-run-path@5.3.0", "", { "dependencies": { "path-key": "^4.0.0" } }, "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ=="],
+
+    "nypm": ["nypm@0.6.4", "", { "dependencies": { "citty": "^0.2.0", "pathe": "^2.0.3", "tinyexec": "^1.0.2" }, "bin": { "nypm": "dist/cli.mjs" } }, "sha512-1TvCKjZyyklN+JJj2TS3P4uSQEInrM/HkkuSXsEzm1ApPgBffOn8gFguNnZf07r/1X6vlryfIqMUkJKQMzlZiw=="],
+
+    "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+
+    "ofetch": ["ofetch@1.5.1", "", { "dependencies": { "destr": "^2.0.5", "node-fetch-native": "^1.6.7", "ufo": "^1.6.1" } }, "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA=="],
+
+    "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
+
+    "on-finished": ["on-finished@2.3.0", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww=="],
+
+    "onetime": ["onetime@6.0.0", "", { "dependencies": { "mimic-fn": "^4.0.0" } }, "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ=="],
+
+    "oniguruma-parser": ["oniguruma-parser@0.12.1", "", {}, "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w=="],
+
+    "oniguruma-to-es": ["oniguruma-to-es@4.3.4", "", { "dependencies": { "oniguruma-parser": "^0.12.1", "regex": "^6.0.1", "regex-recursion": "^6.0.2" } }, "sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA=="],
+
+    "open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
+
+    "p-limit": ["p-limit@5.0.0", "", { "dependencies": { "yocto-queue": "^1.0.0" } }, "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ=="],
+
+    "p-map": ["p-map@7.0.4", "", {}, "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ=="],
+
+    "package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
+
+    "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
+
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
+
+    "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
+
+    "pathval": ["pathval@1.1.1", "", {}, "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ=="],
+
+    "pdf-lib": ["pdf-lib@1.17.1", "", { "dependencies": { "@pdf-lib/standard-fonts": "^1.0.0", "@pdf-lib/upng": "^1.0.1", "pako": "^1.0.11", "tslib": "^1.11.1" } }, "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw=="],
+
+    "perfect-debounce": ["perfect-debounce@2.1.0", "", {}, "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "pkg-types": ["pkg-types@2.3.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig=="],
+
+    "plantuml-encoder": ["plantuml-encoder@1.4.0", "", {}, "sha512-sxMwpDw/ySY1WB2CE3+IdMuEcWibJ72DDOsXLkSmEaSzwEUaYBT6DWgOfBiHGCux4q433X6+OEFWjlVqp7gL6g=="],
+
+    "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
+
+    "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
+
+    "popmotion": ["popmotion@11.0.5", "", { "dependencies": { "framesync": "6.1.2", "hey-listen": "^1.0.8", "style-value-types": "5.1.2", "tslib": "2.4.0" } }, "sha512-la8gPM1WYeFznb/JqF4GiTkRRPZsfaj2+kCxqQgr2MJylMmIKUwBfWW8Wa5fml/8gmtlD5yI01MP1QCZPWmppA=="],
+
+    "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+
+    "postcss-nested": ["postcss-nested@7.0.2", "", { "dependencies": { "postcss-selector-parser": "^7.0.0" }, "peerDependencies": { "postcss": "^8.2.14" } }, "sha512-5osppouFc0VR9/VYzYxO03VaDa3e8F23Kfd6/9qcZTUI8P58GIYlArOET2Wq0ywSl2o2PjELhYOFI4W7l5QHKw=="],
+
+    "postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
+
+    "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
+
+    "pptxgenjs": ["pptxgenjs@4.0.1", "", { "dependencies": { "@types/node": "^22.8.1", "https": "^1.0.0", "image-size": "^1.2.1", "jszip": "^3.10.1" } }, "sha512-TeJISr8wouAuXw4C1F/mC33xbZs/FuEG6nH9FG1Zj+nuPcGMP5YRHl6X+j3HSUnS1f3at6k75ZZXPMZlA5Lj9A=="],
+
+    "pretty-format": ["pretty-format@29.7.0", "", { "dependencies": { "@jest/schemas": "^29.6.3", "ansi-styles": "^5.0.0", "react-is": "^18.0.0" } }, "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ=="],
+
+    "prism-theme-vars": ["prism-theme-vars@0.2.5", "", {}, "sha512-/D8gBTScYzi9afwE6v3TC1U/1YFZ6k+ly17mtVRdLpGy7E79YjJJWkXFgUDHJ2gDksV/ZnXF7ydJ4TvoDm2z/Q=="],
+
+    "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
+
+    "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
+
+    "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
+    "psl": ["psl@1.15.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w=="],
+
+    "public-ip": ["public-ip@8.0.0", "", { "dependencies": { "dns-socket": "^4.2.2", "is-ip": "^5.0.1" } }, "sha512-XzVyz98rNQiTRciAC+I4w45fWWxM9KKedDGNtH4unPwBcWo2Y9n7kgPXqlTiWqKN0EFlIIU1i8yrWOy9mxgZ8g=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
+
+    "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
+
+    "querystringify": ["querystringify@2.2.0", "", {}, "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="],
+
+    "queue": ["queue@6.0.2", "", { "dependencies": { "inherits": "~2.0.3" } }, "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA=="],
+
+    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "rc9": ["rc9@2.1.2", "", { "dependencies": { "defu": "^6.1.4", "destr": "^2.0.3" } }, "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg=="],
+
+    "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+
+    "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
+    "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+
+    "recordrtc": ["recordrtc@5.6.2", "", {}, "sha512-1QNKKNtl7+KcwD1lyOgP3ZlbiJ1d0HtXnypUy7yq49xEERxk31PHvE9RCciDrulPCY7WJ+oz0R9hpNxgsIurGQ=="],
+
+    "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
+
+    "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
+
+    "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "requires-port": ["requires-port@1.0.0", "", {}, "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="],
+
+    "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
+
+    "resolve-global": ["resolve-global@2.0.0", "", { "dependencies": { "global-directory": "^4.0.1" } }, "sha512-gnAQ0Q/KkupGkuiMyX4L0GaBV8iFwlmoXsMtOz+DFTaKmHhOO/dSlP1RMKhpvHv/dh6K/IQkowGJBqUG0NfBUw=="],
+
+    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "robust-predicates": ["robust-predicates@3.0.2", "", {}, "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="],
+
+    "rollup": ["rollup@4.57.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.57.1", "@rollup/rollup-android-arm64": "4.57.1", "@rollup/rollup-darwin-arm64": "4.57.1", "@rollup/rollup-darwin-x64": "4.57.1", "@rollup/rollup-freebsd-arm64": "4.57.1", "@rollup/rollup-freebsd-x64": "4.57.1", "@rollup/rollup-linux-arm-gnueabihf": "4.57.1", "@rollup/rollup-linux-arm-musleabihf": "4.57.1", "@rollup/rollup-linux-arm64-gnu": "4.57.1", "@rollup/rollup-linux-arm64-musl": "4.57.1", "@rollup/rollup-linux-loong64-gnu": "4.57.1", "@rollup/rollup-linux-loong64-musl": "4.57.1", "@rollup/rollup-linux-ppc64-gnu": "4.57.1", "@rollup/rollup-linux-ppc64-musl": "4.57.1", "@rollup/rollup-linux-riscv64-gnu": "4.57.1", "@rollup/rollup-linux-riscv64-musl": "4.57.1", "@rollup/rollup-linux-s390x-gnu": "4.57.1", "@rollup/rollup-linux-x64-gnu": "4.57.1", "@rollup/rollup-linux-x64-musl": "4.57.1", "@rollup/rollup-openbsd-x64": "4.57.1", "@rollup/rollup-openharmony-arm64": "4.57.1", "@rollup/rollup-win32-arm64-msvc": "4.57.1", "@rollup/rollup-win32-ia32-msvc": "4.57.1", "@rollup/rollup-win32-x64-gnu": "4.57.1", "@rollup/rollup-win32-x64-msvc": "4.57.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A=="],
+
+    "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
+
+    "rrweb-cssom": ["rrweb-cssom@0.6.0", "", {}, "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw=="],
+
+    "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
+
+    "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
+
+    "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
+
+    "scule": ["scule@1.3.0", "", {}, "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g=="],
+
+    "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
+
+    "semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "shiki": ["shiki@3.22.0", "", { "dependencies": { "@shikijs/core": "3.22.0", "@shikijs/engine-javascript": "3.22.0", "@shikijs/engine-oniguruma": "3.22.0", "@shikijs/langs": "3.22.0", "@shikijs/themes": "3.22.0", "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-LBnhsoYEe0Eou4e1VgJACes+O6S6QC0w71fCSp5Oya79inkwkm15gQ1UF6VtQ8j/taMDh79hAB49WUk8ALQW3g=="],
+
+    "shiki-magic-move": ["shiki-magic-move@1.2.1", "", { "dependencies": { "diff-match-patch-es": "^1.0.1", "ohash": "^2.0.11" }, "peerDependencies": { "react": "^18.2.0 || ^19.0.0", "shiki": "^1.0.0 || ^2.0.0 || ^3.0.0", "solid-js": "^1.9.1", "svelte": "^5.0.0-0", "vue": "^3.4.0" }, "optionalPeers": ["react", "shiki", "solid-js", "svelte", "vue"] }, "sha512-421QfXnBNbsyOkb+gh/Sm18SSedN7pVc+ZA4gMCEF6YPtvEIntP5CojBiVz9AL0apCRsWeiZfVBEmw0oUP+uMg=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
+
+    "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
+
+    "slidev-marimo-islands": ["slidev-marimo-islands@file:slidev-addon-marimo-islands", { "devDependencies": { "@biomejs/biome": "2.3.7", "@slidev/cli": "latest", "@slidev/types": "latest", "@vitejs/plugin-vue": "^6.0.1", "@vitest/ui": "^1.6.0", "jsdom": "^23.0.0", "vitest": "^1.6.0", "vue": "^3.4.0" }, "peerDependencies": { "@slidev/cli": ">=0.48.0", "vue": "^3.0.0" } }],
+
+    "slidev-marimo-live": ["slidev-marimo-live@file:slidev-addon-marimo-live", { "devDependencies": { "@biomejs/biome": "2.3.7", "@slidev/cli": "latest", "@slidev/types": "latest", "@vitejs/plugin-vue": "^6.0.1", "@vitest/ui": "^1.6.0", "jsdom": "^23.0.0", "vitest": "^1.6.0", "vue": "^3.4.0" }, "peerDependencies": { "@slidev/cli": ">=0.48.0", "vue": "^3.0.0" } }],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "statuses": ["statuses@1.5.0", "", {}, "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-bom-string": ["strip-bom-string@1.0.0", "", {}, "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g=="],
+
+    "strip-final-newline": ["strip-final-newline@3.0.0", "", {}, "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw=="],
+
+    "strip-literal": ["strip-literal@2.1.1", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q=="],
+
+    "style-value-types": ["style-value-types@5.1.2", "", { "dependencies": { "hey-listen": "^1.0.8", "tslib": "2.4.0" } }, "sha512-Vs9fNreYF9j6W2VvuDTP7kepALi7sk0xtk2Tu8Yxi9UoajJdEVpNpCov0HsLTqXvNGKX+Uv09pkozVITi1jf3Q=="],
+
+    "stylis": ["stylis@4.3.6", "", {}, "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ=="],
+
+    "super-regex": ["super-regex@0.2.0", "", { "dependencies": { "clone-regexp": "^3.0.0", "function-timeout": "^0.1.0", "time-span": "^5.1.0" } }, "sha512-WZzIx3rC1CvbMDloLsVw0lkZVKJWbrkJ0k1ghKFmcnPrW1+jWbgTkTEWVtD9lMdmI4jZEz40+naBxl1dCUhXXw=="],
+
+    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
+    "time-span": ["time-span@5.1.0", "", { "dependencies": { "convert-hrtime": "^5.0.0" } }, "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
+
+    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tinypool": ["tinypool@0.8.4", "", {}, "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ=="],
+
+    "tinyspy": ["tinyspy@2.2.1", "", {}, "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
+
+    "tough-cookie": ["tough-cookie@4.1.4", "", { "dependencies": { "psl": "^1.1.33", "punycode": "^2.1.1", "universalify": "^0.2.0", "url-parse": "^1.5.3" } }, "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag=="],
+
+    "tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
+
+    "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
+    "ts-dedent": ["ts-dedent@2.2.0", "", {}, "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ=="],
+
+    "tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
+
+    "twoslash": ["twoslash@0.3.6", "", { "dependencies": { "@typescript/vfs": "^1.6.2", "twoslash-protocol": "0.3.6" }, "peerDependencies": { "typescript": "^5.5.0" } }, "sha512-VuI5OKl+MaUO9UIW3rXKoPgHI3X40ZgB/j12VY6h98Ae1mCBihjPvhOPeJWlxCYcmSbmeZt5ZKkK0dsVtp+6pA=="],
+
+    "twoslash-protocol": ["twoslash-protocol@0.3.6", "", {}, "sha512-FHGsJ9Q+EsNr5bEbgG3hnbkvEBdW5STgPU824AHUjB4kw0Dn4p8tABT7Ncg1Ie6V0+mDg3Qpy41VafZXcQhWMA=="],
+
+    "twoslash-vue": ["twoslash-vue@0.3.6", "", { "dependencies": { "@vue/language-core": "^3.2.0", "twoslash": "0.3.6", "twoslash-protocol": "0.3.6" }, "peerDependencies": { "typescript": "^5.5.0" } }, "sha512-HXYxU+Y7jZiMXJN4980fQNMYflLD8uqKey1qVW5ri8bqYTm2t5ILmOoCOli7esdCHlMq4/No3iQUWBWDhZNs9w=="],
+
+    "type-detect": ["type-detect@4.1.0", "", {}, "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
+
+    "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
+
+    "unconfig": ["unconfig@7.4.2", "", { "dependencies": { "@quansync/fs": "^1.0.0", "defu": "^6.1.4", "jiti": "^2.6.1", "quansync": "^1.0.0", "unconfig-core": "7.4.2" } }, "sha512-nrMlWRQ1xdTjSnSUqvYqJzbTBFugoqHobQj58B2bc8qxHKBBHMNNsWQFP3Cd3/JZK907voM2geYPWqD4VK3MPQ=="],
+
+    "unconfig-core": ["unconfig-core@7.4.2", "", { "dependencies": { "@quansync/fs": "^1.0.0", "quansync": "^1.0.0" } }, "sha512-VgPCvLWugINbXvMQDf8Jh0mlbvNjNC6eSUziHsBCMpxR05OPrNrvDnyatdMjRgcHaaNsCqz+wjNXxNw1kRLHUg=="],
+
+    "unctx": ["unctx@2.5.0", "", { "dependencies": { "acorn": "^8.15.0", "estree-walker": "^3.0.3", "magic-string": "^0.30.21", "unplugin": "^2.3.11" } }, "sha512-p+Rz9x0R7X+CYDkT+Xg8/GhpcShTlU8n+cf9OtOEf7zEQsNcCZO1dPKNRDqvUTaq+P32PMMkxWHwfrxkqfqAYg=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "unhead": ["unhead@2.1.2", "", { "dependencies": { "hookable": "^6.0.1" } }, "sha512-vSihrxyb+zsEUfEbraZBCjdE0p/WSoc2NGDrpwwSNAwuPxhYK1nH3eegf02IENLpn1sUhL8IoO84JWmRQ6tILA=="],
+
+    "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
+    "universalify": ["universalify@0.2.0", "", {}, "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="],
+
+    "unocss": ["unocss@66.6.0", "", { "dependencies": { "@unocss/astro": "66.6.0", "@unocss/cli": "66.6.0", "@unocss/core": "66.6.0", "@unocss/postcss": "66.6.0", "@unocss/preset-attributify": "66.6.0", "@unocss/preset-icons": "66.6.0", "@unocss/preset-mini": "66.6.0", "@unocss/preset-tagify": "66.6.0", "@unocss/preset-typography": "66.6.0", "@unocss/preset-uno": "66.6.0", "@unocss/preset-web-fonts": "66.6.0", "@unocss/preset-wind": "66.6.0", "@unocss/preset-wind3": "66.6.0", "@unocss/preset-wind4": "66.6.0", "@unocss/transformer-attributify-jsx": "66.6.0", "@unocss/transformer-compile-class": "66.6.0", "@unocss/transformer-directives": "66.6.0", "@unocss/transformer-variant-group": "66.6.0", "@unocss/vite": "66.6.0" }, "peerDependencies": { "@unocss/webpack": "66.6.0", "vite": "^2.9.0 || ^3.0.0-0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0 || ^8.0.0-0" }, "optionalPeers": ["@unocss/webpack", "vite"] }, "sha512-B5QsMJzFKeTHPzF5Ehr8tSMuhxzbCR9n+XP0GyhK9/2jTcBdI0/T+rCDDr9m6vUz+lku/coCVz7VAQ2BRAbZJw=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "unplugin": ["unplugin@2.3.11", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww=="],
+
+    "unplugin-icons": ["unplugin-icons@23.0.1", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/utils": "^3.1.0", "local-pkg": "^1.1.2", "obug": "^2.1.1", "unplugin": "^2.3.11" }, "peerDependencies": { "@svgr/core": ">=7.0.0", "@svgx/core": "^1.0.1", "@vue/compiler-sfc": "^3.0.2", "svelte": "^3.0.0 || ^4.0.0 || ^5.0.0" }, "optionalPeers": ["@svgr/core", "@svgx/core", "@vue/compiler-sfc", "svelte"] }, "sha512-rv0XEJepajKzDLvRUWASM8K+8+/CCfZn2jtogXqg6RIp7kpatRc/aFrVJn8ANQA09e++lPEEv9yX8cC9enc+QQ=="],
+
+    "unplugin-utils": ["unplugin-utils@0.3.1", "", { "dependencies": { "pathe": "^2.0.3", "picomatch": "^4.0.3" } }, "sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog=="],
+
+    "unplugin-vue-components": ["unplugin-vue-components@31.0.0", "", { "dependencies": { "chokidar": "^5.0.0", "local-pkg": "^1.1.2", "magic-string": "^0.30.21", "mlly": "^1.8.0", "obug": "^2.1.1", "picomatch": "^4.0.3", "tinyglobby": "^0.2.15", "unplugin": "^2.3.11", "unplugin-utils": "^0.3.1" }, "peerDependencies": { "@nuxt/kit": "^3.2.2 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@nuxt/kit"] }, "sha512-4ULwfTZTLuWJ7+S9P7TrcStYLsSRkk6vy2jt/WTfgUEUb0nW9//xxmrfhyHUEVpZ2UKRRwfRb8Yy15PDbVZf+Q=="],
+
+    "unplugin-vue-markdown": ["unplugin-vue-markdown@29.2.0", "", { "dependencies": { "@mdit-vue/plugin-component": "^3.0.2", "@mdit-vue/plugin-frontmatter": "^3.0.2", "@mdit-vue/types": "^3.0.2", "@types/markdown-it": "^14.1.2", "markdown-it": "^14.1.0", "markdown-it-async": "^2.2.0", "unplugin": "^2.3.10", "unplugin-utils": "^0.3.0" }, "peerDependencies": { "vite": "^2.0.0 || ^3.0.0-0 || ^4.0.0-0 || ^5.0.0-0 || ^6.0.0 || ^7.0.0" } }, "sha512-/x2hFgQ6cWN1Kls+yK5mAI9YDmeTofftynVGgOy1llBlDX1ifaXsQBls/bpORaiwn7cxA7HkOo0wn/xKcrXBHA=="],
+
+    "untun": ["untun@0.1.3", "", { "dependencies": { "citty": "^0.1.5", "consola": "^3.2.3", "pathe": "^1.1.1" }, "bin": { "untun": "bin/untun.mjs" } }, "sha512-4luGP9LMYszMRZwsvyUd9MrxgEGZdZuZgpVQHEEX0lCYFESasVRvZd0EYpCkOIbJKHMuv0LskpXc/8Un+MJzEQ=="],
+
+    "untyped": ["untyped@2.0.0", "", { "dependencies": { "citty": "^0.1.6", "defu": "^6.1.4", "jiti": "^2.4.2", "knitwork": "^1.2.0", "scule": "^1.3.0" }, "bin": { "untyped": "dist/cli.mjs" } }, "sha512-nwNCjxJTjNuLCgFr42fEak5OcLuB3ecca+9ksPFNvtfYSLpjf+iJqSIaSnIile6ZPbKYxI5k2AfXqeopGudK/g=="],
+
+    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
+    "uqr": ["uqr@0.1.2", "", {}, "sha512-MJu7ypHq6QasgF5YRTjqscSzQp/W11zoUk6kvmlH+fmWEs63Y0Eib13hYFwAzagRJcVY8WVnlV+eBDUGMJ5IbA=="],
+
+    "url-parse": ["url-parse@1.5.10", "", { "dependencies": { "querystringify": "^2.1.1", "requires-port": "^1.0.0" } }, "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "utils-merge": ["utils-merge@1.0.1", "", {}, "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="],
+
+    "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
+
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
+
+    "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
+
+    "vite-dev-rpc": ["vite-dev-rpc@1.1.0", "", { "dependencies": { "birpc": "^2.4.0", "vite-hot-client": "^2.1.0" }, "peerDependencies": { "vite": "^2.9.0 || ^3.0.0-0 || ^4.0.0-0 || ^5.0.0-0 || ^6.0.1 || ^7.0.0-0" } }, "sha512-pKXZlgoXGoE8sEKiKJSng4hI1sQ4wi5YT24FCrwrLt6opmkjlqPPVmiPWWJn8M8byMxRGzp1CrFuqQs4M/Z39A=="],
+
+    "vite-hot-client": ["vite-hot-client@2.1.0", "", { "peerDependencies": { "vite": "^2.6.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0" } }, "sha512-7SpgZmU7R+dDnSmvXE1mfDtnHLHQSisdySVR7lO8ceAXvM0otZeuQQ6C8LrS5d/aYyP/QZ0hI0L+dIPrm4YlFQ=="],
+
+    "vite-node": ["vite-node@1.6.1", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.3.4", "pathe": "^1.1.1", "picocolors": "^1.0.0", "vite": "^5.0.0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA=="],
+
+    "vite-plugin-inspect": ["vite-plugin-inspect@11.3.3", "", { "dependencies": { "ansis": "^4.1.0", "debug": "^4.4.1", "error-stack-parser-es": "^1.0.5", "ohash": "^2.0.11", "open": "^10.2.0", "perfect-debounce": "^2.0.0", "sirv": "^3.0.1", "unplugin-utils": "^0.3.0", "vite-dev-rpc": "^1.1.0" }, "peerDependencies": { "vite": "^6.0.0 || ^7.0.0-0" } }, "sha512-u2eV5La99oHoYPHE6UvbwgEqKKOQGz86wMg40CCosP6q8BkB6e5xPneZfYagK4ojPJSj5anHCrnvC20DpwVdRA=="],
+
+    "vite-plugin-remote-assets": ["vite-plugin-remote-assets@2.1.0", "", { "dependencies": { "debug": "^4.4.1", "magic-string": "^0.30.17", "node-fetch-native": "^1.6.7", "ohash": "^2.0.11" }, "peerDependencies": { "vite": ">=5.0.0" } }, "sha512-8ajL5WG5BmYcC8zxeLOa3byCUG2AopKDAdNK7zStPHaRYYz1mxXBaeNFLu6vTEXj8UmXAsb5WlEmBBYwtlPEwA=="],
+
+    "vite-plugin-static-copy": ["vite-plugin-static-copy@3.2.0", "", { "dependencies": { "chokidar": "^3.6.0", "p-map": "^7.0.4", "picocolors": "^1.1.1", "tinyglobby": "^0.2.15" }, "peerDependencies": { "vite": "^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-g2k9z8B/1Bx7D4wnFjPLx9dyYGrqWMLTpwTtPHhcU+ElNZP2O4+4OsyaficiDClus0dzVhdGvoGFYMJxoXZ12Q=="],
+
+    "vite-plugin-vue-server-ref": ["vite-plugin-vue-server-ref@1.0.0", "", { "dependencies": { "debug": "^4.4.0", "klona": "^2.0.6", "mlly": "^1.7.4", "ufo": "^1.5.4" }, "peerDependencies": { "vite": ">=2.0.0", "vue": "^3.0.0" } }, "sha512-6d/JZVrnETM0xa0AVyEcI1bXFpEzQ1EPU5N/gDa7NtXo/7nfJWJhezcWq82Jih6Vf8xtGJjhi1w19AcXAtwmAg=="],
+
+    "vitefu": ["vitefu@1.1.1", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0" }, "optionalPeers": ["vite"] }, "sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ=="],
+
+    "vitest": ["vitest@1.6.1", "", { "dependencies": { "@vitest/expect": "1.6.1", "@vitest/runner": "1.6.1", "@vitest/snapshot": "1.6.1", "@vitest/spy": "1.6.1", "@vitest/utils": "1.6.1", "acorn-walk": "^8.3.2", "chai": "^4.3.10", "debug": "^4.3.4", "execa": "^8.0.1", "local-pkg": "^0.5.0", "magic-string": "^0.30.5", "pathe": "^1.1.1", "picocolors": "^1.0.0", "std-env": "^3.5.0", "strip-literal": "^2.0.0", "tinybench": "^2.5.1", "tinypool": "^0.8.3", "vite": "^5.0.0", "vite-node": "1.6.1", "why-is-node-running": "^2.2.2" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "1.6.1", "@vitest/ui": "1.6.1", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag=="],
+
+    "vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
+
+    "vscode-languageserver": ["vscode-languageserver@9.0.1", "", { "dependencies": { "vscode-languageserver-protocol": "3.17.5" }, "bin": { "installServerIntoExtension": "bin/installServerIntoExtension" } }, "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g=="],
+
+    "vscode-languageserver-protocol": ["vscode-languageserver-protocol@3.17.5", "", { "dependencies": { "vscode-jsonrpc": "8.2.0", "vscode-languageserver-types": "3.17.5" } }, "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg=="],
+
+    "vscode-languageserver-textdocument": ["vscode-languageserver-textdocument@1.0.12", "", {}, "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="],
+
+    "vscode-languageserver-types": ["vscode-languageserver-types@3.17.5", "", {}, "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="],
+
+    "vscode-uri": ["vscode-uri@3.0.8", "", {}, "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw=="],
+
+    "vue": ["vue@3.5.27", "", { "dependencies": { "@vue/compiler-dom": "3.5.27", "@vue/compiler-sfc": "3.5.27", "@vue/runtime-dom": "3.5.27", "@vue/server-renderer": "3.5.27", "@vue/shared": "3.5.27" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-aJ/UtoEyFySPBGarREmN4z6qNKpbEguYHMmXSiOGk69czc+zhs0NF6tEFrY8TZKAl8N/LYAkd4JHVd5E/AsSmw=="],
+
+    "vue-flow-layout": ["vue-flow-layout@0.2.0", "", {}, "sha512-zKgsWWkXq0xrus7H4Mc+uFs1ESrmdTXlO0YNbR6wMdPaFvosL3fMB8N7uTV308UhGy9UvTrGhIY7mVz9eN+L0Q=="],
+
+    "vue-resize": ["vue-resize@2.0.0-alpha.1", "", { "peerDependencies": { "vue": "^3.0.0" } }, "sha512-7+iqOueLU7uc9NrMfrzbG8hwMqchfVfSzpVlCMeJQe4pyibqyoifDNbKTZvwxZKDvGkB+PdFeKvnGZMoEb8esg=="],
+
+    "vue-router": ["vue-router@4.6.4", "", { "dependencies": { "@vue/devtools-api": "^6.6.4" }, "peerDependencies": { "vue": "^3.5.0" } }, "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg=="],
+
+    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
+    "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
+
+    "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
+
+    "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
+    "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+
+    "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
+
+    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
+
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
+
+    "yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
+
+    "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
+
+    "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
+
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/helper-create-class-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@chevrotain/cst-dts-gen/lodash-es": ["lodash-es@4.17.21", "", {}, "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="],
+
+    "@chevrotain/gast/lodash-es": ["lodash-es@4.17.21", "", {}, "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="],
+
+    "@nuxt/kit/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "@quansync/fs/quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
+
+    "@slidev/cli/@slidev/types": ["@slidev/types@52.11.5", "", { "dependencies": { "@antfu/utils": "^9.3.0", "@shikijs/markdown-it": "^3.21.0", "@vitejs/plugin-vue": "^6.0.3", "@vitejs/plugin-vue-jsx": "^5.1.3", "katex": "^0.16.28", "mermaid": "^11.12.2", "monaco-editor": "^0.55.1", "shiki": "^3.21.0", "unocss": "^66.6.0", "unplugin-icons": "^23.0.1", "unplugin-vue-markdown": "^29.2.0", "vite-plugin-inspect": "^11.3.3", "vite-plugin-remote-assets": "^2.1.0", "vite-plugin-static-copy": "^3.2.0", "vite-plugin-vue-server-ref": "^1.0.0", "vue": "^3.5.27", "vue-router": "^4.6.4" } }, "sha512-KPXDC0b7jNHYZy06TrSvNoZ/WVNr5HaWPucmEPxkDF4urJBV0DQ23/fVnBagGsiSrKYHu+mQgCMS+5a++EytEg=="],
+
+    "@slidev/client/@slidev/types": ["@slidev/types@52.11.5", "", { "dependencies": { "@antfu/utils": "^9.3.0", "@shikijs/markdown-it": "^3.21.0", "@vitejs/plugin-vue": "^6.0.3", "@vitejs/plugin-vue-jsx": "^5.1.3", "katex": "^0.16.28", "mermaid": "^11.12.2", "monaco-editor": "^0.55.1", "shiki": "^3.21.0", "unocss": "^66.6.0", "unplugin-icons": "^23.0.1", "unplugin-vue-markdown": "^29.2.0", "vite-plugin-inspect": "^11.3.3", "vite-plugin-remote-assets": "^2.1.0", "vite-plugin-static-copy": "^3.2.0", "vite-plugin-vue-server-ref": "^1.0.0", "vue": "^3.5.27", "vue-router": "^4.6.4" } }, "sha512-KPXDC0b7jNHYZy06TrSvNoZ/WVNr5HaWPucmEPxkDF4urJBV0DQ23/fVnBagGsiSrKYHu+mQgCMS+5a++EytEg=="],
+
+    "@slidev/parser/@slidev/types": ["@slidev/types@52.11.5", "", { "dependencies": { "@antfu/utils": "^9.3.0", "@shikijs/markdown-it": "^3.21.0", "@vitejs/plugin-vue": "^6.0.3", "@vitejs/plugin-vue-jsx": "^5.1.3", "katex": "^0.16.28", "mermaid": "^11.12.2", "monaco-editor": "^0.55.1", "shiki": "^3.21.0", "unocss": "^66.6.0", "unplugin-icons": "^23.0.1", "unplugin-vue-markdown": "^29.2.0", "vite-plugin-inspect": "^11.3.3", "vite-plugin-remote-assets": "^2.1.0", "vite-plugin-static-copy": "^3.2.0", "vite-plugin-vue-server-ref": "^1.0.0", "vue": "^3.5.27", "vue-router": "^4.6.4" } }, "sha512-KPXDC0b7jNHYZy06TrSvNoZ/WVNr5HaWPucmEPxkDF4urJBV0DQ23/fVnBagGsiSrKYHu+mQgCMS+5a++EytEg=="],
+
+    "@unocss/cli/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "@unocss/postcss/css-tree": ["css-tree@3.1.0", "", { "dependencies": { "mdn-data": "2.12.2", "source-map-js": "^1.0.1" } }, "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w=="],
+
+    "@unocss/transformer-attributify-jsx/@babel/parser": ["@babel/parser@7.27.7", "", { "dependencies": { "@babel/types": "^7.27.7" }, "bin": "./bin/babel-parser.js" }, "sha512-qnzXzDXdr/po3bOTbTIQZ7+TxNKxpkN5IifVLXS+r7qwynkZfPyjZfE7hCXbo7IoO9TNcSyibgONsf2HauUd3Q=="],
+
+    "@unocss/transformer-attributify-jsx/@babel/traverse": ["@babel/traverse@7.27.7", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.27.5", "@babel/parser": "^7.27.7", "@babel/template": "^7.27.2", "@babel/types": "^7.27.7", "debug": "^4.3.1", "globals": "^11.1.0" } }, "sha512-X6ZlfR/O/s5EQ/SnUSLzr+6kGnkg8HXGMzpgsMsrJVcfDtH1vIp6ctCN4eZ1LS5c0+te5Cb6Y514fASjMRJ1nw=="],
+
+    "@unocss/transformer-directives/css-tree": ["css-tree@3.1.0", "", { "dependencies": { "mdn-data": "2.12.2", "source-map-js": "^1.0.1" } }, "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w=="],
+
+    "@unocss/vite/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "@vitejs/plugin-vue-jsx/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.2", "", {}, "sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw=="],
+
+    "@vitest/ui/sirv": ["sirv@2.0.4", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ=="],
+
+    "@vue/compiler-core/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "@vue/compiler-sfc/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "@vueuse/motion/@vueuse/core": ["@vueuse/core@13.9.0", "", { "dependencies": { "@types/web-bluetooth": "^0.0.21", "@vueuse/metadata": "13.9.0", "@vueuse/shared": "13.9.0" }, "peerDependencies": { "vue": "^3.5.0" } }, "sha512-ts3regBQyURfCE2BcytLqzm8+MmLlo5Ln/KLoxDVcsZ2gzIwVNnQpQOL/UKV8alUqjSZOlpFZcRNsLRqj+OzyA=="],
+
+    "@vueuse/motion/@vueuse/shared": ["@vueuse/shared@13.9.0", "", { "peerDependencies": { "vue": "^3.5.0" } }, "sha512-e89uuTLMh0U5cZ9iDpEI2senqPGfbPRTHM/0AaQkcxnpqjkZqDYP8rpfm7edOz8s+pOCOROEy1PIveSW8+fL5g=="],
+
+    "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "c12/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "chevrotain/lodash-es": ["lodash-es@4.17.21", "", {}, "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="],
+
+    "cliui/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "cliui/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "connect/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "cssstyle/rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
+
+    "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
+
+    "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
+
+    "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
+    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "finalhandler/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "framesync/tslib": ["tslib@2.4.0", "", {}, "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="],
+
+    "giget/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+
+    "markdown-it/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "mermaid/dompurify": ["dompurify@3.3.1", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q=="],
+
+    "mermaid/marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
+
+    "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "mlly/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "mlly/pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
+
+    "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
+
+    "nypm/citty": ["citty@0.2.0", "", {}, "sha512-8csy5IBFI2ex2hTVpaHN2j+LNE199AgiI7y4dMintrr8i0lQiFn+0AWMZrWdHKIgMOer65f8IThysYhoReqjWA=="],
+
+    "nypm/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "pkg-types/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "popmotion/tslib": ["tslib@2.4.0", "", {}, "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="],
+
+    "slidev-marimo-islands/@slidev/types": ["@slidev/types@52.11.5", "", { "dependencies": { "@antfu/utils": "^9.3.0", "@shikijs/markdown-it": "^3.21.0", "@vitejs/plugin-vue": "^6.0.3", "@vitejs/plugin-vue-jsx": "^5.1.3", "katex": "^0.16.28", "mermaid": "^11.12.2", "monaco-editor": "^0.55.1", "shiki": "^3.21.0", "unocss": "^66.6.0", "unplugin-icons": "^23.0.1", "unplugin-vue-markdown": "^29.2.0", "vite-plugin-inspect": "^11.3.3", "vite-plugin-remote-assets": "^2.1.0", "vite-plugin-static-copy": "^3.2.0", "vite-plugin-vue-server-ref": "^1.0.0", "vue": "^3.5.27", "vue-router": "^4.6.4" } }, "sha512-KPXDC0b7jNHYZy06TrSvNoZ/WVNr5HaWPucmEPxkDF4urJBV0DQ23/fVnBagGsiSrKYHu+mQgCMS+5a++EytEg=="],
+
+    "slidev-marimo-live/@slidev/types": ["@slidev/types@52.11.5", "", { "dependencies": { "@antfu/utils": "^9.3.0", "@shikijs/markdown-it": "^3.21.0", "@vitejs/plugin-vue": "^6.0.3", "@vitejs/plugin-vue-jsx": "^5.1.3", "katex": "^0.16.28", "mermaid": "^11.12.2", "monaco-editor": "^0.55.1", "shiki": "^3.21.0", "unocss": "^66.6.0", "unplugin-icons": "^23.0.1", "unplugin-vue-markdown": "^29.2.0", "vite-plugin-inspect": "^11.3.3", "vite-plugin-remote-assets": "^2.1.0", "vite-plugin-static-copy": "^3.2.0", "vite-plugin-vue-server-ref": "^1.0.0", "vue": "^3.5.27", "vue-router": "^4.6.4" } }, "sha512-KPXDC0b7jNHYZy06TrSvNoZ/WVNr5HaWPucmEPxkDF4urJBV0DQ23/fVnBagGsiSrKYHu+mQgCMS+5a++EytEg=="],
+
+    "style-value-types/tslib": ["tslib@2.4.0", "", {}, "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="],
+
+    "unconfig/quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
+
+    "unconfig-core/quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
+
+    "unplugin-utils/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "vite-node/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
+    "vite-plugin-inspect/open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
+
+    "vite-plugin-static-copy/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
+
+    "vitest/local-pkg": ["local-pkg@0.5.1", "", { "dependencies": { "mlly": "^1.7.3", "pkg-types": "^1.2.1" } }, "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ=="],
+
+    "vitest/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
+    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "wrap-ansi/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "yargs/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "@unocss/postcss/css-tree/mdn-data": ["mdn-data@2.12.2", "", {}, "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA=="],
+
+    "@unocss/transformer-attributify-jsx/@babel/traverse/@babel/parser": ["@babel/parser@7.28.6", "", { "dependencies": { "@babel/types": "^7.28.6" }, "bin": "./bin/babel-parser.js" }, "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ=="],
+
+    "@unocss/transformer-directives/css-tree/mdn-data": ["mdn-data@2.12.2", "", {}, "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA=="],
+
+    "@vueuse/motion/@vueuse/core/@vueuse/metadata": ["@vueuse/metadata@13.9.0", "", {}, "sha512-1AFRvuiGphfF7yWixZa0KwjYH8ulyjDCC0aFgrGRz8+P4kvDFSdXLVfTk5xAN9wEuD1J6z4/myMoYbnHoX07zg=="],
+
+    "cliui/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "connect/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
+
+    "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
+
+    "finalhandler/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "mlly/pkg-types/confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
+
+    "vite-node/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "vite-plugin-inspect/open/wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
+
+    "vite-plugin-static-copy/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+
+    "vitest/local-pkg/pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
+
+    "vitest/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "yargs/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "yargs/string-width/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "vite-node/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "vite-node/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "vite-node/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "vite-node/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "vite-node/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "vite-node/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+
+    "vite-plugin-static-copy/chokidar/readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "vitest/local-pkg/pkg-types/confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
+
+    "vitest/local-pkg/pkg-types/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "vitest/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "vitest/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "vitest/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "vitest/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "vitest/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "vitest/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "vitest/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "vitest/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "vitest/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "vitest/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "vitest/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "vitest/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "vitest/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "vitest/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+
+    "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+  }
+}

--- a/examples/marimo-live-test.md
+++ b/examples/marimo-live-test.md
@@ -2,151 +2,162 @@
 theme: default
 addons:
   - slidev-marimo-live
+highlighter: shiki
 ---
 
-# Marimo Live Bug Fix Validation
+# Marimo Live
 
-Testing the 5 bug fixes in slidev-addon-marimo-live
-
----
-
-# Test 1: Double Execution Prevention
-
-Click the Run button multiple times rapidly. Should only execute once.
-
-```marimo-live autoRun=false
-import time
-print(f"Executed at: {time.time()}")
-```
-
-**Expected:** Console shows single execution, not multiple.
+Interactive Python notebooks embedded in your slides
 
 ---
 
-# Test 2: Plain Text Output
+# Interactive Slider
 
-Basic text output with auto-run.
-
-```marimo-live
-print("Hello from marimo!")
-print("Plain text output works!")
-```
-
----
-
-# Test 3: Markdown Mimetype Support
-
-Tests that markdown content renders correctly.
+Drag the slider and watch the output update in real-time.
 
 ```marimo-live
 import marimo as mo
-mo.md("""
-# Markdown Test
-
-This is **bold** and this is *italic*.
-
-- Item 1
-- Item 2
-- Item 3
-""")
-```
-
-**Expected:** Rendered markdown with headings, bold, italic, and list.
-
----
-
-# Test 4: JSON Output Handling
-
-Tests valid JSON formatting.
-
-```marimo-live
-import json
-data = {"name": "test", "values": [1, 2, 3], "nested": {"a": 1, "b": 2}}
-print(json.dumps(data))
-```
-
-**Expected:** Pretty-printed JSON output.
-
----
-
-# Test 5: Inline Code with Manual Run
-
-Inline code (not from notebook) to test auto-run=false.
-
-```marimo-live autoRun=false
-print("Manual run test")
-import json
-# This outputs invalid JSON-like string to test error handling
-print("{not valid json")
-```
-
-**Expected:** Click Run to execute. Invalid JSON shows as raw text.
-
----
-
-# Test 6: Interactive Slider
-
-Interactive widget to test UI element communication.
-
-```marimo-live
-import marimo as mo
-slider = mo.ui.slider(0, 100, value=50, label="Value")
+slider = mo.ui.slider(1, 100, value=50, label="Select a number")
 slider
 ```
 
 ```marimo-live
 import marimo as mo
-mo.md(f"Slider interaction test")
+squared = slider.value ** 2
+mo.md(f"**Value:** {slider.value} | **Squared:** {squared}")
 ```
 
 ---
 
-# Test 7: Timeout Cleanup Test
+# Dropdown + Altair Chart
 
-Navigate away from this slide and back.
-No console errors should appear about unmounted components.
+Select a column to visualize from the Titanic dataset.
 
-```marimo-live autoRun=true
-print("Timeout cleanup test cell")
+```marimo-live
+import marimo as mo
+dropdown = mo.ui.dropdown(
+    options=["Survived", "Pclass", "Sex", "Age", "Fare"],
+    value="Survived",
+    label="Select column"
+)
+dropdown
 ```
 
-**Instructions:**
-1. Navigate to next slide
-2. Come back
-3. Check browser console for cleanup errors
+```marimo-live
+import marimo as mo
+import polars as pl
+import altair as alt
 
----
+url = "https://raw.githubusercontent.com/datasciencedojo/datasets/master/titanic.csv"
+titanic = pl.read_csv(url)
+col = dropdown.value
 
-# Test 8: Reconnection Test
+if col in ["Age", "Fare"]:
+    chart = alt.Chart(titanic.to_pandas()).mark_bar().encode(
+        alt.X(f"{col}:Q", bin=True), y="count()"
+    ).properties(width=500, height=250)
+else:
+    chart = alt.Chart(titanic.to_pandas()).mark_bar().encode(
+        x=f"{col}:N", y="count()"
+    ).properties(width=500, height=250)
 
-Test that reconnection works after disconnect.
-
-```marimo-live autoRun=false
-import time
-print(f"Reconnection test: {time.time()}")
+mo.ui.altair_chart(chart)
 ```
 
-**Instructions:**
-1. Stop the marimo kernel (Ctrl+C in terminal)
-2. Wait for "Not connected" warning
-3. Restart kernel
-4. Click Reconnect button
-5. Verify it reconnects and works
+---
+
+# Data Explorer
+
+Browse and filter the Titanic dataset interactively.
+
+```marimo-live
+import marimo as mo
+import polars as pl
+
+url = "https://raw.githubusercontent.com/datasciencedojo/datasets/master/titanic.csv"
+titanic = pl.read_csv(url)
+mo.ui.dataframe(titanic)
+```
 
 ---
 
-# Summary
+# Checkbox & Switch
 
-| Bug Fix | Test Method |
-|---------|-------------|
-| Double execution race | Rapid click Run button on slide 2 |
-| Timeout cleanup | Navigate between slides 7-8, check console |
-| reconnectAttempts reset | Disconnect/reconnect on slide 8 |
-| JSON parse error | Run invalid JSON code on slide 5 |
-| Markdown mimetype | View rendered markdown on slide 3 |
+Toggle states that react immediately.
+
+```marimo-live
+import marimo as mo
+check = mo.ui.checkbox(label="Enable feature")
+switch = mo.ui.switch(label="Dark mode")
+mo.hstack([check, switch])
+```
+
+```marimo-live
+import marimo as mo
+mo.md(f"Checkbox: **{check.value}** | Switch: **{switch.value}**")
+```
 
 ---
 
-# End
+# Text Input
 
-All tests completed!
+Type your name and see a greeting.
+
+```marimo-live
+import marimo as mo
+text = mo.ui.text(placeholder="Type something...", label="Name")
+text
+```
+
+```marimo-live
+import marimo as mo
+if text.value:
+    mo.md(f"# Hello, {text.value}!")
+else:
+    mo.md("_Enter your name above_")
+```
+
+---
+
+# How It Works
+
+```
+┌─────────────────┐     WebSocket      ┌─────────────────┐
+│   Slidev        │◄──────────────────►│  Marimo Kernel  │
+│   (Browser)     │                    │  (Python)       │
+└─────────────────┘                    └─────────────────┘
+```
+
+- Full Python kernel running locally
+- Any package: polars, altair, scikit-learn...
+- UI elements sync bidirectionally
+- Cells react to each other automatically
+
+---
+
+# Get Started
+
+```bash
+# Start the marimo kernel
+marimo edit notebook.py --headless --port 2718 --no-token --allow-origins "*"
+
+# Start slidev
+slidev slides.md
+```
+
+Add the addon to your slides:
+
+```yaml
+---
+addons:
+  - slidev-marimo-live
+---
+```
+
+---
+
+# Thanks!
+
+**slidev-addon-marimo-live**
+
+Live Python notebooks in your presentations.

--- a/examples/marimo-live-test.md
+++ b/examples/marimo-live-test.md
@@ -15,11 +15,9 @@ Interactive Python notebooks embedded in your slides
 
 Drag the slider and watch the output update in real-time.
 
-```marimo-live cell=slider_demo
-```
+<MarimoCell cell="slider_demo" />
 
-```marimo-live cell=slider_output
-```
+<MarimoCell cell="slider_output" />
 
 ---
 
@@ -27,8 +25,7 @@ Drag the slider and watch the output update in real-time.
 
 First, let's load the Titanic dataset (shared across slides).
 
-```marimo-live cell=load_titanic
-```
+<MarimoCell cell="load_titanic" />
 
 ---
 
@@ -36,11 +33,9 @@ First, let's load the Titanic dataset (shared across slides).
 
 Select a column to visualize.
 
-```marimo-live cell=dropdown_demo
-```
+<MarimoCell cell="dropdown_demo" />
 
-```marimo-live cell=chart_demo
-```
+<MarimoCell cell="chart_demo" />
 
 ---
 
@@ -48,8 +43,7 @@ Select a column to visualize.
 
 Browse and filter the Titanic dataset interactively.
 
-```marimo-live cell=data_explorer_demo
-```
+<MarimoCell cell="data_explorer_demo" />
 
 ---
 
@@ -57,11 +51,9 @@ Browse and filter the Titanic dataset interactively.
 
 Toggle states that react immediately.
 
-```marimo-live cell=checkbox_demo
-```
+<MarimoCell cell="checkbox_demo" />
 
-```marimo-live cell=checkbox_output
-```
+<MarimoCell cell="checkbox_output" />
 
 ---
 
@@ -69,11 +61,9 @@ Toggle states that react immediately.
 
 Type your name and see a greeting.
 
-```marimo-live cell=text_input_demo
-```
+<MarimoCell cell="text_input_demo" />
 
-```marimo-live cell=text_output
-```
+<MarimoCell cell="text_output" />
 
 ---
 
@@ -103,12 +93,12 @@ marimo edit notebook.py --sandbox --headless --port 2718 --no-token --allow-orig
 slidev slides.md
 ```
 
-Reference cells by name:
+Reference cells with the `<MarimoCell>` component:
 
-~~~markdown
-```marimo-live cell=plot_chart
+```markdown
+<MarimoCell cell="plot_chart" />
+<MarimoCell cell="2" :displayCode="false" />
 ```
-~~~
 
 ---
 

--- a/examples/marimo-live-test.md
+++ b/examples/marimo-live-test.md
@@ -29,9 +29,23 @@ mo.md(f"**Value:** {slider.value} | **Squared:** {squared}")
 
 ---
 
+# Load Data
+
+First, let's load the Titanic dataset (shared across slides).
+
+```marimo-live
+import polars as pl
+
+url = "https://raw.githubusercontent.com/datasciencedojo/datasets/master/titanic.csv"
+titanic = pl.read_csv(url)
+titanic.head()
+```
+
+---
+
 # Dropdown + Altair Chart
 
-Select a column to visualize from the Titanic dataset.
+Select a column to visualize.
 
 ```marimo-live
 import marimo as mo
@@ -45,12 +59,9 @@ dropdown
 
 ```marimo-live
 import marimo as mo
-import polars as pl
 import altair as alt
 
-url = "https://raw.githubusercontent.com/datasciencedojo/datasets/master/titanic.csv"
-titanic = pl.read_csv(url)
-col = dropdown.value
+col = dropdown.value or "Survived"
 
 if col in ["Age", "Fare"]:
     chart = alt.Chart(titanic.to_pandas()).mark_bar().encode(
@@ -72,10 +83,6 @@ Browse and filter the Titanic dataset interactively.
 
 ```marimo-live
 import marimo as mo
-import polars as pl
-
-url = "https://raw.githubusercontent.com/datasciencedojo/datasets/master/titanic.csv"
-titanic = pl.read_csv(url)
 mo.ui.dataframe(titanic)
 ```
 
@@ -139,7 +146,7 @@ else:
 
 ```bash
 # Start the marimo kernel
-marimo edit notebook.py --headless --port 2718 --no-token --allow-origins "*"
+marimo edit notebook.py --sandbox --headless --port 2718 --no-token --allow-origins "*"
 
 # Start slidev
 slidev slides.md

--- a/examples/marimo-live-test.md
+++ b/examples/marimo-live-test.md
@@ -22,7 +22,6 @@ slider
 ```
 
 ```marimo-live
-import marimo as mo
 squared = slider.value ** 2
 mo.md(f"**Value:** {slider.value} | **Squared:** {squared}")
 ```
@@ -48,7 +47,6 @@ titanic.head()
 Select a column to visualize.
 
 ```marimo-live
-import marimo as mo
 dropdown = mo.ui.dropdown(
     options=["Survived", "Pclass", "Sex", "Age", "Fare"],
     value="Survived",
@@ -58,7 +56,6 @@ dropdown
 ```
 
 ```marimo-live
-import marimo as mo
 import altair as alt
 
 col = dropdown.value or "Survived"
@@ -82,7 +79,6 @@ mo.ui.altair_chart(chart)
 Browse and filter the Titanic dataset interactively.
 
 ```marimo-live
-import marimo as mo
 mo.ui.dataframe(titanic)
 ```
 
@@ -93,14 +89,12 @@ mo.ui.dataframe(titanic)
 Toggle states that react immediately.
 
 ```marimo-live
-import marimo as mo
 check = mo.ui.checkbox(label="Enable feature")
 switch = mo.ui.switch(label="Dark mode")
 mo.hstack([check, switch])
 ```
 
 ```marimo-live
-import marimo as mo
 mo.md(f"Checkbox: **{check.value}** | Switch: **{switch.value}**")
 ```
 
@@ -111,17 +105,12 @@ mo.md(f"Checkbox: **{check.value}** | Switch: **{switch.value}**")
 Type your name and see a greeting.
 
 ```marimo-live
-import marimo as mo
 text = mo.ui.text(placeholder="Type something...", label="Name")
 text
 ```
 
 ```marimo-live
-import marimo as mo
-if text.value:
-    mo.md(f"# Hello, {text.value}!")
-else:
-    mo.md("_Enter your name above_")
+mo.md(f"# Hello, {text.value}!" if text.value else "_Enter your name above_")
 ```
 
 ---

--- a/examples/marimo-live-test.md
+++ b/examples/marimo-live-test.md
@@ -15,15 +15,10 @@ Interactive Python notebooks embedded in your slides
 
 Drag the slider and watch the output update in real-time.
 
-```marimo-live
-import marimo as mo
-slider = mo.ui.slider(1, 100, value=50, label="Select a number")
-slider
+```marimo-live cell=slider_demo
 ```
 
-```marimo-live
-squared = slider.value ** 2
-mo.md(f"**Value:** {slider.value} | **Squared:** {squared}")
+```marimo-live cell=slider_output
 ```
 
 ---
@@ -32,12 +27,7 @@ mo.md(f"**Value:** {slider.value} | **Squared:** {squared}")
 
 First, let's load the Titanic dataset (shared across slides).
 
-```marimo-live
-import polars as pl
-
-url = "https://raw.githubusercontent.com/datasciencedojo/datasets/master/titanic.csv"
-titanic = pl.read_csv(url)
-titanic.head()
+```marimo-live cell=load_titanic
 ```
 
 ---
@@ -46,30 +36,10 @@ titanic.head()
 
 Select a column to visualize.
 
-```marimo-live
-dropdown = mo.ui.dropdown(
-    options=["Survived", "Pclass", "Sex", "Age", "Fare"],
-    value="Survived",
-    label="Select column"
-)
-dropdown
+```marimo-live cell=dropdown_demo
 ```
 
-```marimo-live
-import altair as alt
-
-col = dropdown.value or "Survived"
-
-if col in ["Age", "Fare"]:
-    chart = alt.Chart(titanic.to_pandas()).mark_bar().encode(
-        alt.X(f"{col}:Q", bin=True), y="count()"
-    ).properties(width=500, height=250)
-else:
-    chart = alt.Chart(titanic.to_pandas()).mark_bar().encode(
-        x=f"{col}:N", y="count()"
-    ).properties(width=500, height=250)
-
-mo.ui.altair_chart(chart)
+```marimo-live cell=chart_demo
 ```
 
 ---
@@ -78,8 +48,7 @@ mo.ui.altair_chart(chart)
 
 Browse and filter the Titanic dataset interactively.
 
-```marimo-live
-mo.ui.dataframe(titanic)
+```marimo-live cell=data_explorer_demo
 ```
 
 ---
@@ -88,14 +57,10 @@ mo.ui.dataframe(titanic)
 
 Toggle states that react immediately.
 
-```marimo-live
-check = mo.ui.checkbox(label="Enable feature")
-switch = mo.ui.switch(label="Dark mode")
-mo.hstack([check, switch])
+```marimo-live cell=checkbox_demo
 ```
 
-```marimo-live
-mo.md(f"Checkbox: **{check.value}** | Switch: **{switch.value}**")
+```marimo-live cell=checkbox_output
 ```
 
 ---
@@ -104,13 +69,10 @@ mo.md(f"Checkbox: **{check.value}** | Switch: **{switch.value}**")
 
 Type your name and see a greeting.
 
-```marimo-live
-text = mo.ui.text(placeholder="Type something...", label="Name")
-text
+```marimo-live cell=text_input_demo
 ```
 
-```marimo-live
-mo.md(f"# Hello, {text.value}!" if text.value else "_Enter your name above_")
+```marimo-live cell=text_output
 ```
 
 ---
@@ -124,10 +86,10 @@ mo.md(f"# Hello, {text.value}!" if text.value else "_Enter your name above_")
 └─────────────────┘                    └─────────────────┘
 ```
 
+- Write code in your marimo notebook
+- Reference cells by name in slides
 - Full Python kernel running locally
-- Any package: polars, altair, scikit-learn...
 - UI elements sync bidirectionally
-- Cells react to each other automatically
 
 ---
 
@@ -141,14 +103,12 @@ marimo edit notebook.py --sandbox --headless --port 2718 --no-token --allow-orig
 slidev slides.md
 ```
 
-Add the addon to your slides:
+Reference cells by name:
 
-```yaml
----
-addons:
-  - slidev-marimo-live
----
+~~~markdown
+```marimo-live cell=plot_chart
 ```
+~~~
 
 ---
 

--- a/examples/marimo-live-test.md
+++ b/examples/marimo-live-test.md
@@ -67,6 +67,16 @@ Type your name and see a greeting.
 
 ---
 
+# Greeting Demo
+
+Enter your name and see the greeting update!
+
+<MarimoCell cell="greeting_input" :displayCode="false" />
+
+<MarimoCell cell="greeting_output" :displayCode="false" />
+
+---
+
 # How It Works
 
 ```

--- a/examples/notebook.py
+++ b/examples/notebook.py
@@ -49,11 +49,10 @@ def slider_demo(mo):
 def slider_output(mo, slider):
     """Show slider value with calculation"""
     squared = slider.value ** 2
-    mo.md(f"""
+    return mo.md(f"""
 **Value:** {slider.value}
 **Squared:** {squared}
 """)
-    return
 
 
 @app.cell
@@ -84,15 +83,13 @@ def chart_demo(mo, alt, titanic, dropdown):
             y="count()"
         ).properties(width=400, height=200)
 
-    mo.ui.altair_chart(chart)
-    return
+    return mo.ui.altair_chart(chart)
 
 
 @app.cell
 def data_explorer_demo(mo, titanic):
     """Data explorer for Titanic dataset"""
-    mo.ui.dataframe(titanic)
-    return
+    return mo.ui.dataframe(titanic)
 
 
 @app.cell
@@ -107,8 +104,7 @@ def checkbox_demo(mo):
 @app.cell
 def checkbox_output(mo, check, switch):
     """Show checkbox/switch state"""
-    mo.md(f"Checkbox: **{check.value}** | Switch: **{switch.value}**")
-    return
+    return mo.md(f"Checkbox: **{check.value}** | Switch: **{switch.value}**")
 
 
 @app.cell
@@ -122,8 +118,7 @@ def text_input_demo(mo):
 @app.cell
 def text_output(mo, text):
     """Greet the user"""
-    mo.md(f"Hello, **{text.value}**!" if text.value else "_Enter your name above_")
-    return
+    return mo.md(f"Hello, **{text.value}**!" if text.value else "_Enter your name above_")
 
 
 if __name__ == "__main__":

--- a/examples/notebook.py
+++ b/examples/notebook.py
@@ -50,10 +50,11 @@ def slider_demo(mo):
 def slider_output(mo, slider):
     """Show slider value with calculation"""
     squared = slider.value ** 2
-    return mo.md(f"""
+    mo.md(f"""
 **Value:** {slider.value}
 **Squared:** {squared}
 """)
+    # No return - display only
 
 
 @app.cell
@@ -105,7 +106,8 @@ def checkbox_demo(mo):
 @app.cell
 def checkbox_output(mo, check, switch):
     """Show checkbox/switch state"""
-    return mo.md(f"Checkbox: **{check.value}** | Switch: **{switch.value}**")
+    mo.md(f"Checkbox: **{check.value}** | Switch: **{switch.value}**")
+    # No return - display only
 
 
 @app.cell
@@ -119,7 +121,9 @@ def text_input_demo(mo):
 @app.cell
 def text_output(mo, text):
     """Greet the user"""
-    return mo.md(f"Hello, **{text.value}**!" if text.value else "_Enter your name above_")
+    msg = f"Hello, **{text.value}**!" if text.value else "_Enter your name above_"
+    mo.md(msg)
+    # No return - display only
 
 
 @app.cell

--- a/examples/notebook.py
+++ b/examples/notebook.py
@@ -5,6 +5,7 @@
 #     "polars",
 #     "altair",
 #     "pyarrow",
+#     "pandas",
 # ]
 # ///
 
@@ -119,6 +120,20 @@ def text_input_demo(mo):
 def text_output(mo, text):
     """Greet the user"""
     return mo.md(f"Hello, **{text.value}**!" if text.value else "_Enter your name above_")
+
+
+@app.cell
+def greeting_input(mo):
+    """Text input for greeting with default marimonaut"""
+    name_input = mo.ui.text(value="marimonaut 🧑‍🚀", label="Enter your name")
+    name_input
+    return (name_input,)
+
+
+@app.cell
+def greeting_output(mo, name_input):
+    """Display greeting"""
+    return mo.md(f"# Hello, {name_input.value}!")
 
 
 if __name__ == "__main__":

--- a/examples/notebook.py
+++ b/examples/notebook.py
@@ -124,7 +124,7 @@ def text_output(mo, text):
 
 @app.cell
 def greeting_input(mo):
-    """Text input for greeting with default marimonaut"""
+    """Text input for greeting"""
     name_input = mo.ui.text(value="marimonaut 🧑‍🚀", label="Enter your name")
     name_input
     return (name_input,)
@@ -132,8 +132,11 @@ def greeting_input(mo):
 
 @app.cell
 def greeting_output(mo, name_input):
-    """Display greeting"""
-    return mo.md(f"# Hello, {name_input.value}!")
+    """Display personalized greeting"""
+    # Use the UI element's value with a fallback
+    name = name_input.value if name_input.value else "World"
+    mo.md(f"# Hello, {name}!")
+    return
 
 
 if __name__ == "__main__":

--- a/examples/notebook.py
+++ b/examples/notebook.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+#     "polars",
+#     "altair",
+#     "pyarrow",
+# ]
+# ///
+
 import marimo
 
 __generated_with = "0.11.6"
@@ -11,66 +21,111 @@ def _():
 
 
 @app.cell
-def plain_text():
-    """Cell that outputs plain text"""
-    print("Hello from marimo!")
-    return
+def imports():
+    """Load data libraries"""
+    import polars as pl
+    import altair as alt
+    return pl, alt
 
 
 @app.cell
-def valid_json():
-    """Cell that outputs valid JSON"""
-    import json
-    data = {"name": "test", "values": [1, 2, 3], "nested": {"a": 1, "b": 2}}
-    print(json.dumps(data))
-    return
+def load_titanic(pl):
+    """Load Titanic dataset"""
+    url = "https://raw.githubusercontent.com/datasciencedojo/datasets/master/titanic.csv"
+    titanic = pl.read_csv(url)
+    titanic
+    return (titanic,)
 
 
 @app.cell
-def markdown_output(mo):
-    """Cell that outputs markdown content"""
-    mo.md("""
-# Markdown Test
-
-This is **bold** and this is *italic*.
-
-- Item 1
-- Item 2
-- Item 3
-
-```python
-print("code block")
-```
-""")
-    return
-
-
-@app.cell
-def counter_demo(mo):
-    """Interactive counter for testing multiple executions"""
-    import time
-
-    # Add a small delay to make double-execution visible
-    time.sleep(0.1)
-
-    result = f"Executed at: {time.strftime('%H:%M:%S.%f' if hasattr(time, 'strftime') else '%H:%M:%S')}"
-    print(result)
-    mo.md(f"**Execution timestamp:** {time.time()}")
-    return
-
-
-@app.cell
-def interactive_slider(mo):
-    """Interactive slider widget"""
-    slider = mo.ui.slider(0, 100, value=50, label="Value")
+def slider_demo(mo):
+    """Interactive slider"""
+    slider = mo.ui.slider(1, 100, value=50, label="Select a number")
     slider
     return (slider,)
 
 
 @app.cell
 def slider_output(mo, slider):
-    """Shows slider value"""
-    mo.md(f"Slider value: **{slider.value}**")
+    """Show slider value with calculation"""
+    squared = slider.value ** 2
+    mo.md(f"""
+**Value:** {slider.value}
+**Squared:** {squared}
+""")
+    return
+
+
+@app.cell
+def dropdown_demo(mo):
+    """Dropdown selector"""
+    dropdown = mo.ui.dropdown(
+        options=["Survived", "Pclass", "Sex", "Age", "Fare"],
+        value="Survived",
+        label="Select column"
+    )
+    dropdown
+    return (dropdown,)
+
+
+@app.cell
+def chart_demo(mo, alt, titanic, dropdown):
+    """Altair chart based on dropdown selection"""
+    col = dropdown.value
+
+    if col in ["Age", "Fare"]:
+        chart = alt.Chart(titanic.to_pandas()).mark_bar().encode(
+            alt.X(f"{col}:Q", bin=True),
+            y="count()"
+        ).properties(width=400, height=200)
+    else:
+        chart = alt.Chart(titanic.to_pandas()).mark_bar().encode(
+            x=f"{col}:N",
+            y="count()"
+        ).properties(width=400, height=200)
+
+    mo.ui.altair_chart(chart)
+    return
+
+
+@app.cell
+def data_explorer_demo(mo, titanic):
+    """Data explorer for Titanic dataset"""
+    mo.ui.dataframe(titanic)
+    return
+
+
+@app.cell
+def checkbox_demo(mo):
+    """Checkbox and switch demo"""
+    check = mo.ui.checkbox(label="Enable feature")
+    switch = mo.ui.switch(label="Dark mode")
+    mo.hstack([check, switch])
+    return check, switch
+
+
+@app.cell
+def checkbox_output(mo, check, switch):
+    """Show checkbox/switch state"""
+    mo.md(f"Checkbox: **{check.value}** | Switch: **{switch.value}**")
+    return
+
+
+@app.cell
+def text_input_demo(mo):
+    """Text input demo"""
+    text = mo.ui.text(placeholder="Type something...", label="Name")
+    text
+    return (text,)
+
+
+@app.cell
+def text_output(mo, text):
+    """Greet the user"""
+    if text.value:
+        mo.md(f"Hello, **{text.value}**!")
+    else:
+        mo.md("_Enter your name above_")
     return
 
 

--- a/examples/notebook.py
+++ b/examples/notebook.py
@@ -133,10 +133,9 @@ def greeting_input(mo):
 @app.cell
 def greeting_output(mo, name_input):
     """Display personalized greeting"""
-    # Use the UI element's value with a fallback
     name = name_input.value if name_input.value else "World"
     mo.md(f"# Hello, {name}!")
-    return
+    # No return value - display only, don't export variables
 
 
 if __name__ == "__main__":

--- a/examples/notebook.py
+++ b/examples/notebook.py
@@ -122,10 +122,7 @@ def text_input_demo(mo):
 @app.cell
 def text_output(mo, text):
     """Greet the user"""
-    if text.value:
-        mo.md(f"Hello, **{text.value}**!")
-    else:
-        mo.md("_Enter your name above_")
+    mo.md(f"Hello, **{text.value}**!" if text.value else "_Enter your name above_")
     return
 
 

--- a/justfile
+++ b/justfile
@@ -19,12 +19,12 @@ restart-slidev: clear-cache
     @timeout 30 sh -c 'until curl -s http://localhost:3033 > /dev/null 2>&1; do sleep 1; done' || echo "Warning: Slidev may not have started"
     @echo "Slidev running at http://localhost:3033"
 
-# Restart marimo kernel with sandbox
+# Restart marimo kernel with sandbox (edit mode for cell access)
 restart-kernel:
     @echo "Killing existing kernel..."
     lsof -i :2718 -t | xargs kill 2>/dev/null || true
     sleep 1
-    @echo "Starting marimo kernel..."
+    @echo "Starting marimo kernel (edit mode)..."
     nohup uv run marimo edit examples/notebook.py --sandbox --headless --port 2718 --no-token --allow-origins "*" > /dev/null 2>&1 &
     @echo "Waiting for kernel to start..."
     @timeout 30 sh -c 'until curl -s http://localhost:2718 > /dev/null 2>&1; do sleep 1; done' || echo "Warning: Kernel may not have started"

--- a/justfile
+++ b/justfile
@@ -1,0 +1,39 @@
+# Justfile for slidev-marimo development
+
+# Clear all caches and reinstall dependencies
+clear-cache:
+    @echo "Clearing Vite cache..."
+    rm -rf node_modules/.vite 2>/dev/null || true
+    @echo "Reinstalling local packages..."
+    bun install
+    @echo "Cache cleared!"
+
+# Restart slidev with fresh cache
+restart-slidev: clear-cache
+    @echo "Killing existing slidev..."
+    pkill -f "slidev examples/marimo-live-test.md" 2>/dev/null || true
+    sleep 1
+    @echo "Starting slidev..."
+    (sleep 86400 | bun run slidev examples/marimo-live-test.md --port 3033) &
+    sleep 5
+    @echo "Slidev running at http://localhost:3033"
+
+# Restart marimo kernel with sandbox
+restart-kernel:
+    @echo "Killing existing kernel..."
+    lsof -i :2718 -t | xargs kill 2>/dev/null || true
+    sleep 1
+    @echo "Starting marimo kernel..."
+    (sleep 86400 | uv run marimo edit examples/notebook.py --sandbox --headless --port 2718 --no-token --allow-origins "*") &
+    sleep 8
+    @echo "Kernel running at http://localhost:2718"
+
+# Restart both kernel and slidev
+restart-all: restart-kernel restart-slidev
+
+# Check if services are running
+status:
+    @echo "Marimo kernel (port 2718):"
+    @lsof -i :2718 -sTCP:LISTEN 2>/dev/null || echo "  Not running"
+    @echo "Slidev (port 3033):"
+    @lsof -i :3033 -sTCP:LISTEN 2>/dev/null || echo "  Not running"

--- a/justfile
+++ b/justfile
@@ -11,11 +11,12 @@ clear-cache:
 # Restart slidev with fresh cache
 restart-slidev: clear-cache
     @echo "Killing existing slidev..."
-    pkill -f "slidev examples/marimo-live-test.md" 2>/dev/null || true
+    pkill -f "node.*slidev" 2>/dev/null || true
     sleep 1
     @echo "Starting slidev..."
-    (sleep 86400 | bun run slidev examples/marimo-live-test.md --port 3033) &
-    sleep 5
+    nohup bun run slidev examples/marimo-live-test.md --port 3033 > /dev/null 2>&1 &
+    @echo "Waiting for slidev to start..."
+    @timeout 30 sh -c 'until curl -s http://localhost:3033 > /dev/null 2>&1; do sleep 1; done' || echo "Warning: Slidev may not have started"
     @echo "Slidev running at http://localhost:3033"
 
 # Restart marimo kernel with sandbox
@@ -24,8 +25,9 @@ restart-kernel:
     lsof -i :2718 -t | xargs kill 2>/dev/null || true
     sleep 1
     @echo "Starting marimo kernel..."
-    (sleep 86400 | uv run marimo edit examples/notebook.py --sandbox --headless --port 2718 --no-token --allow-origins "*") &
-    sleep 8
+    nohup uv run marimo edit examples/notebook.py --sandbox --headless --port 2718 --no-token --allow-origins "*" > /dev/null 2>&1 &
+    @echo "Waiting for kernel to start..."
+    @timeout 30 sh -c 'until curl -s http://localhost:2718 > /dev/null 2>&1; do sleep 1; done' || echo "Warning: Kernel may not have started"
     @echo "Kernel running at http://localhost:2718"
 
 # Restart both kernel and slidev

--- a/slidev-addon-marimo-live/README.md
+++ b/slidev-addon-marimo-live/README.md
@@ -53,37 +53,28 @@ For sandbox mode, add a PEP 723 header to your notebook:
 ---
 # My Slide
 
-```marimo-live
-import pandas as pd
-import numpy as np
-
-df = pd.DataFrame({
-    'x': np.random.randn(100),
-    'y': np.random.randn(100)
-})
-df.describe()
-```
+<MarimoCell cell="plot_chart" />
 ---
 ```
 
 ## Usage
 
-### Referencing Notebook Cells (Recommended)
+### Referencing Notebook Cells
 
-The best way to use marimo-live is to reference cells from your marimo notebook. This keeps your code in one place with full IDE support.
+Use `<MarimoCell>` to embed cells from your notebook:
 
 ```markdown
-# Reference by cell name (function name in marimo)
-```marimo-live cell=plot_chart
-```
+<!-- Reference by cell name (function name in marimo) -->
+<MarimoCell cell="plot_chart" />
 
-# Reference by index (0-based)
-```marimo-live cell=2
-```
+<!-- Reference by index (0-based) -->
+<MarimoCell cell="2" />
 
-# With options
-```marimo-live cell=plot_chart displayCode=false
-```
+<!-- Hide code display -->
+<MarimoCell cell="chart_demo" :displayCode="false" />
+
+<!-- Disable auto-run -->
+<MarimoCell cell="expensive_computation" :autoRun="false" />
 ```
 
 Cell names come from the function names in your marimo notebook:
@@ -97,48 +88,26 @@ def plot_chart():  # <- This becomes the cell name
     return plt.gcf()
 ```
 
-### Inline Code (Alternative)
+### MarimoCell Props
 
-You can also write code directly in the slides, but this is less recommended:
-
-```markdown
-```marimo-live
-import pandas as pd
-df = pd.read_csv('data.csv')
-df.head()
-```
-```
-
-### Supported Flags
-
-| Flag | Default | Description |
+| Prop | Default | Description |
 |------|---------|-------------|
-| `cell` | - | Reference a notebook cell by name, ID, or index |
+| `cell` | required | Cell name, ID, or index from the notebook |
 | `displayCode` | `true` | Show the code editor |
 | `autoRun` | `true` | Auto-execute on slide load |
-| `codePosition` | `bottom` | Position of code: `top` or `bottom` |
-| `cellId` | auto | Custom cell ID (only for inline code) |
-| `hideLines` | `[]` | Line numbers to hide (e.g., `[1,2,3]`) |
 
-Example with flags:
+### Vue Component (Advanced)
 
-```markdown
-```marimo-live cell=data_viz displayCode=false autoRun=true
-```
-```
-
-### Vue Component
-
-You can also use the component directly:
+You can also use the components directly in Vue:
 
 ```vue
 <template>
-  <!-- Reference a notebook cell -->
-  <MarimoLive cell="plot_chart" />
+  <!-- Recommended: MarimoCell for notebook cells -->
+  <MarimoCell cell="plot_chart" />
 
-  <!-- Or use inline code -->
+  <!-- MarimoLive for more options -->
   <MarimoLive
-    :code="code"
+    cell="plot_chart"
     :display-code="true"
     :auto-run="true"
     code-position="top"
@@ -146,15 +115,21 @@ You can also use the component directly:
 </template>
 
 <script setup>
-import { MarimoLive } from 'slidev-marimo-live'
-
-const code = `
-import pandas as pd
-df = pd.read_csv('data.csv')
-df.head()
-`
+import { MarimoCell, MarimoLive } from 'slidev-marimo-live'
 </script>
 ```
+
+### MarimoLive Props (Advanced)
+
+| Prop | Default | Description |
+|------|---------|-------------|
+| `cell` | - | Reference a notebook cell by name, ID, or index |
+| `code` | - | Inline Python code (only if `cell` not provided) |
+| `displayCode` | `true` | Show the code editor |
+| `autoRun` | `true` | Auto-execute on slide load |
+| `codePosition` | `bottom` | Position of code: `top` or `bottom` |
+| `cellId` | auto | Custom cell ID (only for inline code) |
+| `hideLines` | `[]` | Line numbers to hide (e.g., `[1,2,3]`) |
 
 ## Configuration
 
@@ -193,7 +168,7 @@ if (typeof window !== 'undefined') {
 │                   SLIDEV PRESENTATION                    │
 │                                                          │
 │  ┌────────────────────────────────────────────────────┐ │
-│  │                 MarimoLive.vue                      │ │
+│  │           MarimoCell / MarimoLive.vue              │ │
 │  │  - Read-only code display                          │ │
 │  │  - Run button / keyboard shortcuts                 │ │
 │  │  - Output rendering                                │ │

--- a/slidev-addon-marimo-live/README.md
+++ b/slidev-addon-marimo-live/README.md
@@ -96,6 +96,8 @@ def plot_chart():  # <- This becomes the cell name
 | `displayCode` | `true` | Show the code editor |
 | `autoRun` | `true` | Auto-execute on slide load |
 
+**Note:** For boolean `false` values, use the `:` prefix (Vue binding syntax): `:displayCode="false"`. Props default to `true` so you can omit them entirely when you want the default behavior.
+
 ### Vue Component (Advanced)
 
 You can also use the components directly in Vue:

--- a/slidev-addon-marimo-live/README.md
+++ b/slidev-addon-marimo-live/README.md
@@ -31,11 +31,20 @@ Add to your presentation's `package.json`:
 ### 2. Start the marimo server
 
 ```bash
-# Using the provided script
-./slidev-addon-marimo-live/scripts/start-kernel.sh notebook.py
+# With sandbox mode (recommended - auto-installs deps from notebook)
+marimo edit notebook.py --sandbox --headless --port 2718 --no-token --allow-origins "*"
 
-# Or manually
+# Or without sandbox (requires deps pre-installed)
 marimo edit notebook.py --headless --port 2718 --no-token --allow-origins "*"
+```
+
+For sandbox mode, add a PEP 723 header to your notebook:
+
+```python
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["marimo", "polars", "altair"]
+# ///
 ```
 
 ### 3. Use in your slides

--- a/slidev-addon-marimo-live/components/MarimoCell.vue
+++ b/slidev-addon-marimo-live/components/MarimoCell.vue
@@ -21,9 +21,10 @@
  * ```
  */
 
+import { computed } from "vue";
 import MarimoLive from "./MarimoLive.vue";
 
-defineProps<{
+const props = defineProps<{
   /** Required: Cell name, ID, or index from the notebook */
   cell: string;
   /** Show the code editor (default: true) */
@@ -31,8 +32,16 @@ defineProps<{
   /** Auto-execute on mount (default: true) */
   autoRun?: boolean;
 }>();
+
+// Only include props that are explicitly set to avoid overriding MarimoLive defaults
+const boundProps = computed(() => {
+  const result: Record<string, unknown> = { cell: props.cell };
+  if (props.displayCode !== undefined) result.displayCode = props.displayCode;
+  if (props.autoRun !== undefined) result.autoRun = props.autoRun;
+  return result;
+});
 </script>
 
 <template>
-  <MarimoLive :cell="cell" :displayCode="displayCode" :autoRun="autoRun" />
+  <MarimoLive v-bind="boundProps" />
 </template>

--- a/slidev-addon-marimo-live/components/MarimoCell.vue
+++ b/slidev-addon-marimo-live/components/MarimoCell.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+/**
+ * MarimoCell Component
+ *
+ * Semantic alias for MarimoLive when referencing notebook cells.
+ * Use this component to embed cells from your marimo notebook in slides.
+ *
+ * @example Reference a notebook cell by name
+ * ```vue
+ * <MarimoCell cell="plot_chart" />
+ * ```
+ *
+ * @example Reference a notebook cell by index
+ * ```vue
+ * <MarimoCell cell="2" />
+ * ```
+ *
+ * @example Hide code display
+ * ```vue
+ * <MarimoCell cell="chart_demo" :displayCode="false" />
+ * ```
+ */
+
+import MarimoLive from "./MarimoLive.vue";
+
+defineProps<{
+  /** Required: Cell name, ID, or index from the notebook */
+  cell: string;
+  /** Show the code editor (default: true) */
+  displayCode?: boolean;
+  /** Auto-execute on mount (default: true) */
+  autoRun?: boolean;
+}>();
+</script>
+
+<template>
+  <MarimoLive :cell="cell" :displayCode="displayCode" :autoRun="autoRun" />
+</template>

--- a/slidev-addon-marimo-live/components/MarimoCell.vue
+++ b/slidev-addon-marimo-live/components/MarimoCell.vue
@@ -24,14 +24,21 @@
 import { computed } from "vue";
 import MarimoLive from "./MarimoLive.vue";
 
-const props = defineProps<{
-  /** Required: Cell name, ID, or index from the notebook */
-  cell: string;
-  /** Show the code editor (default: true) */
-  displayCode?: boolean;
-  /** Auto-execute on mount (default: true) */
-  autoRun?: boolean;
-}>();
+const props = withDefaults(
+  defineProps<{
+    /** Required: Cell name, ID, or index from the notebook */
+    cell: string;
+    /** Show the code editor (default: inherited from MarimoLive) */
+    displayCode?: boolean;
+    /** Auto-execute on mount (default: inherited from MarimoLive) */
+    autoRun?: boolean;
+  }>(),
+  {
+    // Use undefined to inherit MarimoLive's defaults
+    displayCode: undefined,
+    autoRun: undefined,
+  },
+);
 
 // Only include props that are explicitly set to avoid overriding MarimoLive defaults
 const boundProps = computed(() => {

--- a/slidev-addon-marimo-live/components/MarimoLive.vue
+++ b/slidev-addon-marimo-live/components/MarimoLive.vue
@@ -187,8 +187,10 @@ async function runCell() {
 let autoRunTimeout: ReturnType<typeof setTimeout> | null = null;
 
 // Check if cell already has output from instantiation
+// Checks for null, undefined, AND empty string to avoid false positives
 const hasExistingOutput = computed(() => {
-  return cellState.value?.output !== null && cellState.value?.output !== undefined;
+  const output = cellState.value?.output;
+  return output !== null && output !== undefined && output !== '';
 });
 
 // Auto-run on mount if enabled and connected

--- a/slidev-addon-marimo-live/components/MarimoLive.vue
+++ b/slidev-addon-marimo-live/components/MarimoLive.vue
@@ -383,12 +383,17 @@ function handleKeydown(event: KeyboardEvent) {
 
     <!-- Code display (read-only, with syntax highlighting) -->
     <div v-else-if="displayCode && cellCode" class="code-container">
-      <pre class="code-block"><code ref="codeElement" class="language-python"><span
+      <div class="code-wrapper">
+        <div class="line-numbers" aria-hidden="true">
+          <span v-for="(_, idx) in highlightedLines" :key="idx" class="line-number">{{ idx + 1 }}</span>
+        </div>
+        <pre class="code-block"><code ref="codeElement" class="language-python"><span
   v-for="(lineHtml, idx) in highlightedLines"
   :key="idx"
   class="code-line"
-><span class="line-number">{{ idx + 1 }}</span><span class="line-content" v-html="lineHtml || '&nbsp;'"></span>
+><span class="line-content" v-html="lineHtml || ' '"></span>
 </span></code></pre>
+      </div>
     </div>
 
     <!-- Output display -->
@@ -412,28 +417,66 @@ function handleKeydown(event: KeyboardEvent) {
 </template>
 
 <style scoped>
+/* ==========================================================================
+   One Dark Pro Code Theme - Refined for Presentations
+   Inspired by Atom One Dark with enhanced readability
+   ========================================================================== */
+
+/* CSS Custom Properties for easy theming */
 .marimo-live {
-  position: relative;
-  border: 1px solid #374151;
-  border-radius: 8px;
-  overflow: hidden;
-  background: #1f2937;
-  margin: 1rem 0;
+  --code-bg: #282c34;
+  --code-gutter-bg: #21252b;
+  --code-gutter-border: #181a1f;
+  --code-text: #abb2bf;
+  --code-line-number: #495162;
+  --code-line-number-active: #636d83;
+
+  /* One Dark Pro syntax colors */
+  --syntax-comment: #5c6370;
+  --syntax-keyword: #c678dd;
+  --syntax-string: #98c379;
+  --syntax-number: #d19a66;
+  --syntax-function: #61afef;
+  --syntax-class: #e5c07b;
+  --syntax-operator: #56b6c2;
+  --syntax-punctuation: #abb2bf;
+  --syntax-boolean: #d19a66;
+  --syntax-decorator: #e5c07b;
+
+  /* Output area */
+  --output-bg: #1e2227;
+  --output-border: #181a1f;
+  --output-text: #d4d4d4;
+
+  /* Accent colors */
+  --accent-blue: #528bff;
+  --accent-green: #98c379;
+  --accent-red: #e06c75;
+  --accent-yellow: #e5c07b;
 }
 
-/* Light mode */
-:root:not(.dark) .marimo-live {
-  border-color: #e5e7eb;
-  background: #ffffff;
+.marimo-live {
+  position: relative;
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--code-bg);
+  margin: 1rem 0;
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.2),
+    0 2px 4px -2px rgba(0, 0, 0, 0.1),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  font-family: 'JetBrains Mono', 'Fira Code', 'SF Mono', 'Cascadia Code', 'Consolas', monospace;
 }
 
 .marimo-live:focus {
-  outline: 2px solid #3b82f6;
+  outline: 2px solid var(--accent-blue);
   outline-offset: 2px;
 }
 
 .marimo-live.is-running {
-  border-color: #3b82f6;
+  box-shadow:
+    0 0 0 2px var(--accent-blue),
+    0 4px 6px -1px rgba(0, 0, 0, 0.2);
 }
 
 /* Code position variants */
@@ -442,67 +485,53 @@ function handleKeydown(event: KeyboardEvent) {
   flex-direction: column;
 }
 
-.marimo-live.code-position-top .code-container {
-  order: 1;
-}
+.marimo-live.code-position-top .code-container { order: 1; }
+.marimo-live.code-position-top .output-container { order: 2; }
+.marimo-live.code-position-bottom .code-container { order: 2; }
+.marimo-live.code-position-bottom .output-container { order: 1; }
 
-.marimo-live.code-position-top .output-container {
-  order: 2;
-}
+/* ==========================================================================
+   Status Bar
+   ========================================================================== */
 
-.marimo-live.code-position-bottom .code-container {
-  order: 2;
-}
-
-.marimo-live.code-position-bottom .output-container {
-  order: 1;
-}
-
-/* Status bar */
 .status-bar {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 0.75rem;
-  background: #374151;
-  border-bottom: 1px solid #4b5563;
+  gap: 0.625rem;
+  padding: 0.5rem 1rem;
+  background: var(--code-gutter-bg);
+  border-bottom: 1px solid var(--code-gutter-border);
   font-size: 0.75rem;
-  color: #9ca3af;
-}
-
-:root:not(.dark) .status-bar {
-  background: #f9fafb;
-  border-bottom-color: #e5e7eb;
-  color: #6b7280;
+  color: var(--code-line-number-active);
 }
 
 .status-indicator {
-  width: 12px;
-  height: 12px;
+  width: 10px;
+  height: 10px;
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
 .status-indicator .dot {
-  width: 8px;
-  height: 8px;
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
-  background: #9ca3af;
+  background: var(--code-line-number);
 }
 
 .status-indicator.running .spinner {
   width: 10px;
   height: 10px;
-  border: 2px solid #3b82f6;
+  border: 2px solid var(--accent-blue);
   border-top-color: transparent;
   border-radius: 50%;
-  animation: spin 1s linear infinite;
+  animation: spin 0.8s linear infinite;
 }
 
 .status-indicator.idle .check {
-  color: #22c55e;
-  font-weight: bold;
+  color: var(--accent-green);
+  font-size: 0.875rem;
 }
 
 @keyframes spin {
@@ -510,8 +539,8 @@ function handleKeydown(event: KeyboardEvent) {
 }
 
 .status-text {
-  color: #6b7280;
   text-transform: capitalize;
+  letter-spacing: 0.02em;
 }
 
 .status-actions {
@@ -520,178 +549,269 @@ function handleKeydown(event: KeyboardEvent) {
 
 .run-button,
 .interrupt-button {
-  padding: 0.25rem 0.5rem;
+  padding: 0.25rem 0.625rem;
   border: none;
   border-radius: 4px;
-  font-size: 0.75rem;
+  font-size: 0.6875rem;
+  font-weight: 500;
   cursor: pointer;
-  transition: background 0.15s;
+  transition: all 0.15s ease;
+  letter-spacing: 0.02em;
 }
 
 .run-button {
-  background: #3b82f6;
+  background: var(--accent-blue);
   color: white;
 }
 
 .run-button:hover:not(:disabled) {
-  background: #2563eb;
+  background: #4080f0;
+  transform: translateY(-1px);
 }
 
 .run-button:disabled {
-  opacity: 0.5;
+  opacity: 0.4;
   cursor: not-allowed;
 }
 
 .interrupt-button {
-  background: #ef4444;
+  background: var(--accent-red);
   color: white;
 }
 
 .interrupt-button:hover {
-  background: #dc2626;
+  background: #d35d66;
 }
 
-/* Code container */
+/* ==========================================================================
+   Code Container - The Heart of the Component
+   ========================================================================== */
+
 .code-container {
-  background: #1f2937;
+  background: var(--code-bg);
+}
+
+.code-wrapper {
+  display: flex;
   overflow-x: auto;
 }
 
+/* Line Numbers Gutter - Separate column for clean alignment */
+.line-numbers {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 1rem 0;
+  background: var(--code-gutter-bg);
+  border-right: 1px solid var(--code-gutter-border);
+  text-align: right;
+  user-select: none;
+  min-width: 3.5rem;
+}
+
+.line-number {
+  display: block;
+  padding: 0 1rem 0 0.75rem;
+  font-size: 0.8125rem;
+  line-height: 1.625;
+  color: var(--code-line-number);
+  font-variant-numeric: tabular-nums;
+  transition: color 0.15s ease;
+}
+
+.line-number:hover {
+  color: var(--code-line-number-active);
+}
+
+/* Code Block */
 .code-block {
+  flex: 1;
   margin: 0;
-  padding: 0.75rem 0;
-  font-family: "Fira Mono", monospace;
-  font-size: 0.875rem;
-  line-height: 1.5;
+  padding: 1rem 1.25rem;
+  background: transparent;
+  overflow-x: auto;
 }
 
 .code-line {
   display: block;
-}
-
-.line-number {
-  display: inline-block;
-  width: 3rem;
-  padding-right: 1rem;
-  text-align: right;
-  color: #9ca3af;
-  user-select: none;
+  line-height: 1.625;
+  min-height: 1.625em;
 }
 
 .line-content {
-  color: #abb2bf;
+  font-size: 0.8125rem;
+  color: var(--code-text);
+  white-space: pre;
 }
 
-/* Prism.js syntax highlighting - One Dark theme colors */
+/* ==========================================================================
+   Syntax Highlighting - One Dark Pro Colors
+   ========================================================================== */
+
+/* Comments */
 .line-content :deep(.token.comment),
 .line-content :deep(.token.prolog),
 .line-content :deep(.token.doctype),
 .line-content :deep(.token.cdata) {
-  color: #5c6370;
+  color: var(--syntax-comment);
   font-style: italic;
 }
 
+/* Keywords: if, for, def, class, return, import, etc. */
 .line-content :deep(.token.keyword) {
-  color: #c678dd;
+  color: var(--syntax-keyword);
 }
 
+/* Built-in functions and types */
 .line-content :deep(.token.builtin) {
-  color: #e5c07b;
+  color: var(--syntax-class);
 }
 
+/* Function names */
 .line-content :deep(.token.function) {
-  color: #61afef;
+  color: var(--syntax-function);
 }
 
+/* Strings */
 .line-content :deep(.token.string),
-.line-content :deep(.token.triple-quoted-string) {
-  color: #98c379;
-}
-
-.line-content :deep(.token.number) {
-  color: #d19a66;
-}
-
-.line-content :deep(.token.operator) {
-  color: #56b6c2;
-}
-
-.line-content :deep(.token.punctuation) {
-  color: #abb2bf;
-}
-
-.line-content :deep(.token.class-name) {
-  color: #e5c07b;
-}
-
-.line-content :deep(.token.boolean) {
-  color: #d19a66;
-}
-
-.line-content :deep(.token.decorator) {
-  color: #e5c07b;
-}
-
-.line-content :deep(.token.attr-name) {
-  color: #d19a66;
-}
-
+.line-content :deep(.token.triple-quoted-string),
 .line-content :deep(.token.attr-value) {
-  color: #98c379;
+  color: var(--syntax-string);
 }
 
-/* Output container */
+/* Numbers */
+.line-content :deep(.token.number),
+.line-content :deep(.token.boolean) {
+  color: var(--syntax-number);
+}
+
+/* Operators: =, +, -, *, /, etc. */
+.line-content :deep(.token.operator) {
+  color: var(--syntax-operator);
+}
+
+/* Punctuation: (), [], {}, etc. */
+.line-content :deep(.token.punctuation) {
+  color: var(--syntax-punctuation);
+}
+
+/* Class names */
+.line-content :deep(.token.class-name) {
+  color: var(--syntax-class);
+}
+
+/* Decorators: @property, @staticmethod */
+.line-content :deep(.token.decorator),
+.line-content :deep(.token.annotation) {
+  color: var(--syntax-decorator);
+}
+
+/* Attribute names */
+.line-content :deep(.token.attr-name) {
+  color: var(--syntax-number);
+}
+
+/* ==========================================================================
+   Output Container
+   ========================================================================== */
+
 .output-container {
-  padding: 0.75rem;
-  min-height: 40px;
-  background: #1f2937;
-  color: #f9fafb;
+  padding: 1rem 1.25rem;
+  min-height: 2.5rem;
+  background: var(--output-bg);
+  border-top: 1px solid var(--output-border);
+  color: var(--output-text);
+  font-size: 0.875rem;
+  line-height: 1.5;
 }
 
-:root:not(.dark) .output-container {
-  background: #ffffff;
-  color: #1f2937;
+/* When output is empty, show subtle placeholder state */
+.output-container:empty::before {
+  content: '';
+  display: block;
+  height: 1.5rem;
 }
 
-/* Cell not found warning */
+/* ==========================================================================
+   Warning States
+   ========================================================================== */
+
 .cell-not-found {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 1rem;
-  background: #fef3c7;
-  font-size: 0.875rem;
-  color: #92400e;
+  gap: 0.625rem;
+  padding: 1rem 1.25rem;
+  background: rgba(229, 192, 123, 0.1);
+  border-left: 3px solid var(--accent-yellow);
+  font-size: 0.8125rem;
+  color: var(--accent-yellow);
 }
 
-/* Connection warning */
 .connection-warning {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 0.75rem;
-  background: #fef3c7;
-  border-top: 1px solid #fcd34d;
+  gap: 0.625rem;
+  padding: 0.625rem 1rem;
+  background: rgba(229, 192, 123, 0.08);
+  border-top: 1px solid rgba(229, 192, 123, 0.2);
   font-size: 0.75rem;
-  color: #92400e;
+  color: var(--accent-yellow);
 }
 
 .warning-icon {
-  font-size: 1rem;
+  font-size: 0.875rem;
+  opacity: 0.9;
 }
 
 .reconnect-button {
   margin-left: auto;
   padding: 0.25rem 0.5rem;
-  background: #f59e0b;
-  color: white;
+  background: var(--accent-yellow);
+  color: #1e2227;
   border: none;
   border-radius: 4px;
-  font-size: 0.75rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
   cursor: pointer;
+  transition: all 0.15s ease;
 }
 
 .reconnect-button:hover {
-  background: #d97706;
+  filter: brightness(1.1);
+  transform: translateY(-1px);
+}
+
+/* ==========================================================================
+   Light Mode Overrides (when Slidev is in light mode)
+   ========================================================================== */
+
+:root:not(.dark) .marimo-live {
+  --code-bg: #fafafa;
+  --code-gutter-bg: #f0f0f0;
+  --code-gutter-border: #e0e0e0;
+  --code-text: #383a42;
+  --code-line-number: #9d9d9f;
+  --code-line-number-active: #6a6a6c;
+
+  /* One Light syntax colors */
+  --syntax-comment: #a0a1a7;
+  --syntax-keyword: #a626a4;
+  --syntax-string: #50a14f;
+  --syntax-number: #986801;
+  --syntax-function: #4078f2;
+  --syntax-class: #c18401;
+  --syntax-operator: #0184bc;
+  --syntax-punctuation: #383a42;
+  --syntax-boolean: #986801;
+  --syntax-decorator: #c18401;
+
+  --output-bg: #ffffff;
+  --output-border: #e8e8e8;
+  --output-text: #383a42;
+
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.08),
+    0 2px 4px -2px rgba(0, 0, 0, 0.04),
+    inset 0 0 0 1px rgba(0, 0, 0, 0.06);
 }
 </style>

--- a/slidev-addon-marimo-live/components/MarimoLive.vue
+++ b/slidev-addon-marimo-live/components/MarimoLive.vue
@@ -61,10 +61,11 @@ const props = withDefaults(
 const kernel = useMarimoKernel();
 
 // Resolve cell reference to notebook cell
-// Depend on isKernelReady to re-compute when notebook cells are registered
+// Depend on notebookCellsVersion which increments when cells are registered
 const notebookCell = computed(() => {
-  // Access isKernelReady to create reactive dependency
-  const ready = kernel.isKernelReady.value;
+  // Access notebookCellsVersion to create reactive dependency
+  // This triggers re-computation when registerNotebookCells() is called
+  const version = kernel.notebookCellsVersion?.value ?? 0;
 
   if (!props.cell) return null;
 

--- a/slidev-addon-marimo-live/components/MarimoLive.vue
+++ b/slidev-addon-marimo-live/components/MarimoLive.vue
@@ -185,35 +185,43 @@ let autoRunTimeout: ReturnType<typeof setTimeout> | null = null;
 // Auto-run on mount if enabled and connected
 onMounted(() => {
   if (props.autoRun) {
-    // Wait for kernel to be ready
-    const unwatch = watch(
+    // Check if already ready - run immediately
+    if (kernel.isKernelReady.value && kernel.isConnected.value && !hasRun.value) {
+      runCell();
+      return;
+    }
+
+    // Otherwise, watch for kernel to become ready
+    let unwatch: (() => void) | null = null;
+    let unwatchConnection: (() => void) | null = null;
+
+    const cleanup = () => {
+      if (unwatch) { unwatch(); unwatch = null; }
+      if (unwatchConnection) { unwatchConnection(); unwatchConnection = null; }
+    };
+
+    unwatch = watch(
       () => kernel.isKernelReady.value,
       (ready) => {
         if (ready && !hasRun.value) {
           runCell();
-          unwatch();
+          cleanup();
         }
       },
-      { immediate: true },
     );
 
-    // Also watch connection state
-    const unwatchConnection = watch(
+    unwatchConnection = watch(
       () => kernel.isConnected.value,
       (connected) => {
         if (connected && kernel.isKernelReady.value && !hasRun.value) {
           runCell();
-          unwatchConnection();
+          cleanup();
         }
       },
-      { immediate: true },
     );
 
     // Cleanup watchers after 10s if never triggered
-    autoRunTimeout = setTimeout(() => {
-      unwatch();
-      unwatchConnection();
-    }, 10000);
+    autoRunTimeout = setTimeout(cleanup, 10000);
   }
 });
 

--- a/slidev-addon-marimo-live/components/MarimoLive.vue
+++ b/slidev-addon-marimo-live/components/MarimoLive.vue
@@ -391,7 +391,7 @@ function handleKeydown(event: KeyboardEvent) {
   v-for="(lineHtml, idx) in highlightedLines"
   :key="idx"
   class="code-line"
-><span class="line-content" v-html="lineHtml || ' '"></span>
+><span class="line-content" v-html="lineHtml || '\u00A0'"></span>
 </span></code></pre>
       </div>
     </div>

--- a/slidev-addon-marimo-live/components/MarimoLive.vue
+++ b/slidev-addon-marimo-live/components/MarimoLive.vue
@@ -61,7 +61,11 @@ const props = withDefaults(
 const kernel = useMarimoKernel();
 
 // Resolve cell reference to notebook cell
+// Depend on isKernelReady to re-compute when notebook cells are registered
 const notebookCell = computed(() => {
+  // Access isKernelReady to create reactive dependency
+  const ready = kernel.isKernelReady.value;
+
   if (!props.cell) return null;
 
   // Try by ID first
@@ -135,7 +139,7 @@ const cellState = computed(() => kernel.getCellState(myCellId.value));
 
 // Derived state
 const output = computed(() => cellState.value?.output || null);
-const console = computed(() => cellState.value?.console || []);
+const consoleMessages = computed(() => cellState.value?.console || []);
 const error = computed(
   () => localError.value || cellState.value?.error || null,
 );
@@ -323,7 +327,7 @@ function handleKeydown(event: KeyboardEvent) {
     <div class="output-container">
       <MarimoOutput
         :output="output"
-        :console="console"
+        :console="consoleMessages"
         :error="error"
       />
     </div>

--- a/slidev-addon-marimo-live/components/MarimoLive.vue
+++ b/slidev-addon-marimo-live/components/MarimoLive.vue
@@ -28,6 +28,7 @@
  * ```
  */
 
+import DOMPurify from "dompurify";
 import { computed, getCurrentInstance, nextTick, onMounted, onUnmounted, ref, watch } from "vue";
 import { useMarimoKernel } from "../composables/useMarimoKernel";
 import MarimoOutput from "./MarimoOutput.vue";
@@ -155,7 +156,12 @@ const highlightedCode = computed(() => {
   // Try to use Prism if available
   if (typeof window !== "undefined" && window.Prism?.languages?.python) {
     try {
-      return window.Prism.highlight(code, window.Prism.languages.python, "python");
+      const highlighted = window.Prism.highlight(code, window.Prism.languages.python, "python");
+      // Sanitize to prevent XSS - only allow span tags with class attributes
+      return DOMPurify.sanitize(highlighted, {
+        ALLOWED_TAGS: ['span'],
+        ALLOWED_ATTR: ['class']
+      });
     } catch {
       // Fall back to plain text
     }
@@ -182,11 +188,6 @@ function highlightCode() {
       window.Prism.highlightElement(codeElement.value);
     }
   });
-}
-
-// Listen for Prism ready event
-if (typeof window !== "undefined") {
-  window.addEventListener("prism-ready", highlightCode, { once: true });
 }
 
 // Get cell state from kernel
@@ -250,6 +251,11 @@ const hasExistingOutput = computed(() => {
 
 // Auto-run on mount if enabled and connected
 onMounted(() => {
+  // Listen for Prism ready event for syntax highlighting
+  if (typeof window !== "undefined") {
+    window.addEventListener("prism-ready", highlightCode, { once: true });
+  }
+
   if (props.autoRun) {
     // If cell already has output from auto_instantiate, don't re-run
     if (hasExistingOutput.value) {
@@ -312,6 +318,11 @@ onMounted(() => {
 
 // Cleanup on unmount
 onUnmounted(() => {
+  // Remove prism-ready listener in case it hasn't fired yet
+  if (typeof window !== "undefined") {
+    window.removeEventListener("prism-ready", highlightCode);
+  }
+
   if (autoRunTimeout) {
     clearTimeout(autoRunTimeout);
     autoRunTimeout = null;

--- a/slidev-addon-marimo-live/components/MarimoLive.vue
+++ b/slidev-addon-marimo-live/components/MarimoLive.vue
@@ -28,9 +28,20 @@
  * ```
  */
 
-import { computed, getCurrentInstance, onMounted, onUnmounted, ref, watch } from "vue";
+import { computed, getCurrentInstance, nextTick, onMounted, onUnmounted, ref, watch } from "vue";
 import { useMarimoKernel } from "../composables/useMarimoKernel";
 import MarimoOutput from "./MarimoOutput.vue";
+
+// Declare Prism type for syntax highlighting
+declare global {
+  interface Window {
+    Prism?: {
+      highlight: (code: string, grammar: unknown, language: string) => string;
+      languages: Record<string, unknown>;
+      highlightElement: (element: Element) => void;
+    };
+  }
+}
 
 const props = withDefaults(
   defineProps<{
@@ -48,12 +59,15 @@ const props = withDefaults(
     cellId?: string;
     /** Auto-run code on mount */
     autoRun?: boolean;
+    /** Show status bar with run button (hidden by default for clean presentation) */
+    showStatusBar?: boolean;
   }>(),
   {
     displayCode: true,
     hideLines: () => [],
     codePosition: "bottom",
     autoRun: true,
+    showStatusBar: false,
   },
 );
 
@@ -130,10 +144,50 @@ const processedCode = computed(() => {
     .join("\n");
 });
 
-// Display code with syntax highlighting placeholder
-const displayLines = computed(() => {
-  return processedCode.value.split("\n");
+// Ref for code element (for Prism highlighting)
+const codeElement = ref<HTMLElement | null>(null);
+
+// Highlighted code (with Prism syntax highlighting)
+const highlightedCode = computed(() => {
+  const code = processedCode.value;
+  if (!code) return "";
+
+  // Try to use Prism if available
+  if (typeof window !== "undefined" && window.Prism?.languages?.python) {
+    try {
+      return window.Prism.highlight(code, window.Prism.languages.python, "python");
+    } catch {
+      // Fall back to plain text
+    }
+  }
+
+  // Fallback: escape HTML and return plain code
+  return code
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 });
+
+// Add line numbers to highlighted code
+const highlightedLines = computed(() => {
+  const html = highlightedCode.value;
+  if (!html) return [];
+  return html.split("\n");
+});
+
+// Highlight code when Prism becomes available
+function highlightCode() {
+  nextTick(() => {
+    if (codeElement.value && window.Prism?.highlightElement) {
+      window.Prism.highlightElement(codeElement.value);
+    }
+  });
+}
+
+// Listen for Prism ready event
+if (typeof window !== "undefined") {
+  window.addEventListener("prism-ready", highlightCode, { once: true });
+}
 
 // Get cell state from kernel
 const cellState = computed(() => kernel.getCellState(myCellId.value));
@@ -281,8 +335,8 @@ function handleKeydown(event: KeyboardEvent) {
     @keydown="handleKeydown"
     tabindex="0"
   >
-    <!-- Status bar -->
-    <div class="status-bar">
+    <!-- Status bar (hidden by default for clean presentation) -->
+    <div v-if="showStatusBar" class="status-bar">
       <div class="status-indicator" :class="status">
         <span v-if="status === 'running'" class="spinner"></span>
         <span v-else-if="status === 'idle' && hasRun" class="check">&#10003;</span>
@@ -316,13 +370,13 @@ function handleKeydown(event: KeyboardEvent) {
       <span>Cell "{{ cell }}" not found in notebook</span>
     </div>
 
-    <!-- Code display (read-only) -->
+    <!-- Code display (read-only, with syntax highlighting) -->
     <div v-else-if="displayCode && cellCode" class="code-container">
-      <pre class="code-block"><code class="language-python"><span
-  v-for="(line, idx) in displayLines"
+      <pre class="code-block"><code ref="codeElement" class="language-python"><span
+  v-for="(lineHtml, idx) in highlightedLines"
   :key="idx"
   class="code-line"
-><span class="line-number">{{ idx + 1 }}</span><span class="line-content">{{ line }}</span>
+><span class="line-number">{{ idx + 1 }}</span><span class="line-content" v-html="lineHtml || '&nbsp;'"></span>
 </span></code></pre>
     </div>
 
@@ -335,8 +389,8 @@ function handleKeydown(event: KeyboardEvent) {
       />
     </div>
 
-    <!-- Connection status warning -->
-    <div v-if="!kernel.isConnected.value" class="connection-warning">
+    <!-- Connection status warning (only show when status bar is visible) -->
+    <div v-if="showStatusBar && !kernel.isConnected.value" class="connection-warning">
       <span class="warning-icon">&#9888;</span>
       <span>Not connected to marimo kernel</span>
       <button @click="kernel.connect()" class="reconnect-button">
@@ -349,11 +403,17 @@ function handleKeydown(event: KeyboardEvent) {
 <style scoped>
 .marimo-live {
   position: relative;
-  border: 1px solid #e5e7eb;
+  border: 1px solid #374151;
   border-radius: 8px;
   overflow: hidden;
-  background: #ffffff;
+  background: #1f2937;
   margin: 1rem 0;
+}
+
+/* Light mode */
+:root:not(.dark) .marimo-live {
+  border-color: #e5e7eb;
+  background: #ffffff;
 }
 
 .marimo-live:focus {
@@ -393,9 +453,16 @@ function handleKeydown(event: KeyboardEvent) {
   align-items: center;
   gap: 0.5rem;
   padding: 0.5rem 0.75rem;
-  background: #f9fafb;
-  border-bottom: 1px solid #e5e7eb;
+  background: #374151;
+  border-bottom: 1px solid #4b5563;
   font-size: 0.75rem;
+  color: #9ca3af;
+}
+
+:root:not(.dark) .status-bar {
+  background: #f9fafb;
+  border-bottom-color: #e5e7eb;
+  color: #6b7280;
 }
 
 .status-indicator {
@@ -501,13 +568,78 @@ function handleKeydown(event: KeyboardEvent) {
 }
 
 .line-content {
-  color: #f9fafb;
+  color: #abb2bf;
+}
+
+/* Prism.js syntax highlighting - One Dark theme colors */
+.line-content :deep(.token.comment),
+.line-content :deep(.token.prolog),
+.line-content :deep(.token.doctype),
+.line-content :deep(.token.cdata) {
+  color: #5c6370;
+  font-style: italic;
+}
+
+.line-content :deep(.token.keyword) {
+  color: #c678dd;
+}
+
+.line-content :deep(.token.builtin) {
+  color: #e5c07b;
+}
+
+.line-content :deep(.token.function) {
+  color: #61afef;
+}
+
+.line-content :deep(.token.string),
+.line-content :deep(.token.triple-quoted-string) {
+  color: #98c379;
+}
+
+.line-content :deep(.token.number) {
+  color: #d19a66;
+}
+
+.line-content :deep(.token.operator) {
+  color: #56b6c2;
+}
+
+.line-content :deep(.token.punctuation) {
+  color: #abb2bf;
+}
+
+.line-content :deep(.token.class-name) {
+  color: #e5c07b;
+}
+
+.line-content :deep(.token.boolean) {
+  color: #d19a66;
+}
+
+.line-content :deep(.token.decorator) {
+  color: #e5c07b;
+}
+
+.line-content :deep(.token.attr-name) {
+  color: #d19a66;
+}
+
+.line-content :deep(.token.attr-value) {
+  color: #98c379;
 }
 
 /* Output container */
 .output-container {
   padding: 0.75rem;
   min-height: 40px;
+  background: #1f2937;
+  color: #f9fafb;
+}
+
+:root:not(.dark) .output-container {
+  background: #ffffff;
+  color: #1f2937;
 }
 
 /* Cell not found warning */

--- a/slidev-addon-marimo-live/components/MarimoLive.vue
+++ b/slidev-addon-marimo-live/components/MarimoLive.vue
@@ -182,9 +182,20 @@ async function runCell() {
 // Track timeout for cleanup
 let autoRunTimeout: ReturnType<typeof setTimeout> | null = null;
 
+// Check if cell already has output from instantiation
+const hasExistingOutput = computed(() => {
+  return cellState.value?.output !== null && cellState.value?.output !== undefined;
+});
+
 // Auto-run on mount if enabled and connected
 onMounted(() => {
   if (props.autoRun) {
+    // If cell already has output from auto_instantiate, don't re-run
+    if (hasExistingOutput.value) {
+      hasRun.value = true;
+      return;
+    }
+
     // Check if already ready - run immediately
     if (kernel.isKernelReady.value && kernel.isConnected.value && !hasRun.value) {
       runCell();
@@ -205,6 +216,12 @@ onMounted(() => {
       () => kernel.isKernelReady.value,
       (ready) => {
         if (ready && !hasRun.value) {
+          // Check again for existing output (may have arrived while waiting)
+          if (hasExistingOutput.value) {
+            hasRun.value = true;
+            cleanup();
+            return;
+          }
           runCell();
           cleanup();
         }
@@ -215,6 +232,12 @@ onMounted(() => {
       () => kernel.isConnected.value,
       (connected) => {
         if (connected && kernel.isKernelReady.value && !hasRun.value) {
+          // Check again for existing output
+          if (hasExistingOutput.value) {
+            hasRun.value = true;
+            cleanup();
+            return;
+          }
           runCell();
           cleanup();
         }

--- a/slidev-addon-marimo-live/components/MarimoLive.vue
+++ b/slidev-addon-marimo-live/components/MarimoLive.vue
@@ -196,6 +196,7 @@ onMounted(() => {
     let unwatchConnection: (() => void) | null = null;
 
     const cleanup = () => {
+      if (autoRunTimeout) { clearTimeout(autoRunTimeout); autoRunTimeout = null; }
       if (unwatch) { unwatch(); unwatch = null; }
       if (unwatchConnection) { unwatchConnection(); unwatchConnection = null; }
     };

--- a/slidev-addon-marimo-live/components/MarimoOutput.vue
+++ b/slidev-addon-marimo-live/components/MarimoOutput.vue
@@ -150,18 +150,36 @@ const sanitizedConsoleHtml = computed(() => {
   return DOMPurify.sanitize(consoleOutput.value);
 });
 
+// Track timeout for cleanup
+let sliderStyleTimeout: ReturnType<typeof setTimeout> | null = null;
+
 // When HTML content changes, trigger slider styling after render
 // This ensures sliders that are dynamically added get proper styling
-watch(htmlContent, (newContent) => {
+watch(htmlContent, (newContent, _oldContent, onCleanup) => {
+  // Clear any pending timeout from previous watch
+  if (sliderStyleTimeout) {
+    clearTimeout(sliderStyleTimeout);
+    sliderStyleTimeout = null;
+  }
+
   if (newContent && newContent.includes("marimo-slider")) {
     // Wait for DOM update then inject slider styles
     nextTick(() => {
       // Small delay to let custom elements initialize
-      setTimeout(() => {
+      sliderStyleTimeout = setTimeout(() => {
         injectAllSliderStyles();
+        sliderStyleTimeout = null;
       }, 100);
     });
   }
+
+  // Cleanup on unmount or before next watch callback
+  onCleanup(() => {
+    if (sliderStyleTimeout) {
+      clearTimeout(sliderStyleTimeout);
+      sliderStyleTimeout = null;
+    }
+  });
 });
 </script>
 

--- a/slidev-addon-marimo-live/components/MarimoOutput.vue
+++ b/slidev-addon-marimo-live/components/MarimoOutput.vue
@@ -4,12 +4,14 @@
  *
  * Renders cell output from the marimo kernel.
  * Supports HTML, images, JSON, and plain text.
+ * Also handles hydration of marimo UI elements like sliders.
  */
 
-import { computed } from "vue";
 import DOMPurify from "dompurify";
+import { computed, nextTick, watch } from "vue";
 import type { CellOutput } from "../setup/message-parser";
 import { extractHtml } from "../setup/message-parser";
+import { injectAllSliderStyles } from "../setup/slider-styles";
 
 const props = defineProps<{
   output: CellOutput | null;
@@ -146,6 +148,20 @@ const consoleHasHtml = computed(() => {
 const sanitizedConsoleHtml = computed(() => {
   if (!consoleOutput.value) return "";
   return DOMPurify.sanitize(consoleOutput.value);
+});
+
+// When HTML content changes, trigger slider styling after render
+// This ensures sliders that are dynamically added get proper styling
+watch(htmlContent, (newContent) => {
+  if (newContent && newContent.includes("marimo-slider")) {
+    // Wait for DOM update then inject slider styles
+    nextTick(() => {
+      // Small delay to let custom elements initialize
+      setTimeout(() => {
+        injectAllSliderStyles();
+      }, 100);
+    });
+  }
 });
 </script>
 

--- a/slidev-addon-marimo-live/components/MarimoOutput.vue
+++ b/slidev-addon-marimo-live/components/MarimoOutput.vue
@@ -7,6 +7,7 @@
  */
 
 import { computed } from "vue";
+import DOMPurify from "dompurify";
 import type { CellOutput } from "../setup/message-parser";
 import { extractHtml } from "../setup/message-parser";
 
@@ -18,7 +19,9 @@ const props = defineProps<{
 
 const htmlContent = computed(() => {
   if (!props.output) return null;
-  return extractHtml(props.output);
+  const html = extractHtml(props.output);
+  // Sanitize HTML to prevent XSS
+  return html ? DOMPurify.sanitize(html) : null;
 });
 
 // Console array is normalized by kernel-connection.ts; this handles data field rendering
@@ -33,10 +36,21 @@ const consoleOutput = computed(() => {
     .join("\n");
 });
 
-// Check if console output contains HTML that should be rendered
+// Check if console output contains actual HTML tags from marimo's formatter
+// More specific pattern to avoid false positives with comparison operators
 const consoleHasHtml = computed(() => {
   if (!consoleOutput.value) return false;
-  return /<[a-z][\s\S]*>/i.test(consoleOutput.value);
+  // Match marimo's traceback HTML patterns: <span class="..."> or paired tags
+  return (
+    /<(span|div|pre|code)[^>]*class=/i.test(consoleOutput.value) ||
+    /<(span|div|pre|code)[^>]*>[\s\S]*<\/\1>/i.test(consoleOutput.value)
+  );
+});
+
+// Sanitize console HTML output
+const sanitizedConsoleHtml = computed(() => {
+  if (!consoleOutput.value) return "";
+  return DOMPurify.sanitize(consoleOutput.value);
 });
 </script>
 
@@ -55,11 +69,11 @@ const consoleHasHtml = computed(() => {
       v-html="htmlContent"
     />
 
-    <!-- Console output (render as HTML if it contains HTML tags) -->
+    <!-- Console output (render as sanitized HTML if it contains HTML tags) -->
     <div
       v-if="consoleOutput && consoleHasHtml"
       class="output-console output-console-html"
-      v-html="consoleOutput"
+      v-html="sanitizedConsoleHtml"
     />
     <pre
       v-else-if="consoleOutput"

--- a/slidev-addon-marimo-live/components/MarimoOutput.vue
+++ b/slidev-addon-marimo-live/components/MarimoOutput.vue
@@ -19,64 +19,104 @@ const props = defineProps<{
 
 // Configure DOMPurify to allow marimo's custom elements
 const MARIMO_TAGS = [
-  'marimo-ui-element',
-  'marimo-slider',
-  'marimo-dropdown',
-  'marimo-checkbox',
-  'marimo-switch',
-  'marimo-text',
-  'marimo-text-area',
-  'marimo-button',
-  'marimo-number',
-  'marimo-date',
-  'marimo-radio',
-  'marimo-multiselect',
-  'marimo-file',
-  'marimo-dataframe',
-  'marimo-table',
-  'marimo-code-editor',
-  'marimo-chart',
-  'marimo-altair',
-  'marimo-plotly',
-  'marimo-html',
-  'marimo-md',
-  'marimo-accordion',
-  'marimo-tabs',
-  'marimo-tree',
-  'marimo-stat',
-  'marimo-callout',
-  'marimo-progress',
-  'marimo-status',
-  'marimo-lazy',
-  'marimo-anywidget',
+  "marimo-ui-element",
+  "marimo-slider",
+  "marimo-dropdown",
+  "marimo-checkbox",
+  "marimo-switch",
+  "marimo-text",
+  "marimo-text-area",
+  "marimo-button",
+  "marimo-number",
+  "marimo-date",
+  "marimo-radio",
+  "marimo-multiselect",
+  "marimo-file",
+  "marimo-dataframe",
+  "marimo-table",
+  "marimo-code-editor",
+  "marimo-chart",
+  "marimo-altair",
+  "marimo-plotly",
+  "marimo-html",
+  "marimo-md",
+  "marimo-accordion",
+  "marimo-tabs",
+  "marimo-tree",
+  "marimo-stat",
+  "marimo-callout",
+  "marimo-progress",
+  "marimo-status",
+  "marimo-lazy",
+  "marimo-anywidget",
 ];
 
+// Attributes allowed on marimo custom elements
 const MARIMO_ATTRS = [
-  'object-id',
-  'random-id',
-  'data-*',
-  'label',
-  'min',
-  'max',
-  'step',
-  'value',
-  'disabled',
-  'placeholder',
+  "object-id",
+  "random-id",
+  "label",
+  "min",
+  "max",
+  "step",
+  "value",
+  "disabled",
+  "placeholder",
 ];
+
+// Whitelist of safe attribute names for marimo elements (prevents XSS via attribute injection)
+const SAFE_ATTR_NAMES = new Set([
+  ...MARIMO_ATTRS,
+  "class",
+  "style",
+  "id",
+  "name",
+  "type",
+  "aria-label",
+  "aria-describedby",
+  "aria-hidden",
+  "role",
+  "tabindex",
+  "title",
+  "checked",
+  "selected",
+  "readonly",
+  "required",
+  "multiple",
+  "pattern",
+  "maxlength",
+  "minlength",
+  "autocomplete",
+  "autofocus",
+  "form",
+  "list",
+  "accept",
+  "src",
+  "alt",
+  "width",
+  "height",
+]);
 
 const htmlContent = computed(() => {
   if (!props.output) return null;
   const html = extractHtml(props.output);
   // Sanitize HTML to prevent XSS, but allow marimo's custom elements
-  return html ? DOMPurify.sanitize(html, {
-    ADD_TAGS: MARIMO_TAGS,
-    ADD_ATTR: MARIMO_ATTRS,
-    CUSTOM_ELEMENT_HANDLING: {
-      tagNameCheck: (tagName) => tagName.startsWith('marimo-'),
-      attributeNameCheck: () => true,
-      allowCustomizedBuiltInElements: true,
-    },
-  }) : null;
+  return html
+    ? DOMPurify.sanitize(html, {
+        ADD_TAGS: MARIMO_TAGS,
+        ADD_ATTR: MARIMO_ATTRS,
+        CUSTOM_ELEMENT_HANDLING: {
+          tagNameCheck: (tagName) => tagName.startsWith("marimo-"),
+          attributeNameCheck: (attrName) => {
+            // Allow known safe attributes and data-* attributes
+            return (
+              SAFE_ATTR_NAMES.has(attrName) || attrName.startsWith("data-")
+            );
+          },
+          allowCustomizedBuiltInElements: true,
+        },
+      })
+    : null;
 });
 
 // Console array is normalized by kernel-connection.ts; this handles data field rendering

--- a/slidev-addon-marimo-live/components/MarimoOutput.vue
+++ b/slidev-addon-marimo-live/components/MarimoOutput.vue
@@ -32,6 +32,12 @@ const consoleOutput = computed(() => {
     })
     .join("\n");
 });
+
+// Check if console output contains HTML that should be rendered
+const consoleHasHtml = computed(() => {
+  if (!consoleOutput.value) return false;
+  return /<[a-z][\s\S]*>/i.test(consoleOutput.value);
+});
 </script>
 
 <template>
@@ -49,9 +55,14 @@ const consoleOutput = computed(() => {
       v-html="htmlContent"
     />
 
-    <!-- Console output -->
+    <!-- Console output (render as HTML if it contains HTML tags) -->
+    <div
+      v-if="consoleOutput && consoleHasHtml"
+      class="output-console output-console-html"
+      v-html="consoleOutput"
+    />
     <pre
-      v-if="consoleOutput"
+      v-else-if="consoleOutput"
       class="output-console"
     >{{ consoleOutput }}</pre>
 

--- a/slidev-addon-marimo-live/components/MarimoOutput.vue
+++ b/slidev-addon-marimo-live/components/MarimoOutput.vue
@@ -17,11 +17,66 @@ const props = defineProps<{
   error?: string | null;
 }>();
 
+// Configure DOMPurify to allow marimo's custom elements
+const MARIMO_TAGS = [
+  'marimo-ui-element',
+  'marimo-slider',
+  'marimo-dropdown',
+  'marimo-checkbox',
+  'marimo-switch',
+  'marimo-text',
+  'marimo-text-area',
+  'marimo-button',
+  'marimo-number',
+  'marimo-date',
+  'marimo-radio',
+  'marimo-multiselect',
+  'marimo-file',
+  'marimo-dataframe',
+  'marimo-table',
+  'marimo-code-editor',
+  'marimo-chart',
+  'marimo-altair',
+  'marimo-plotly',
+  'marimo-html',
+  'marimo-md',
+  'marimo-accordion',
+  'marimo-tabs',
+  'marimo-tree',
+  'marimo-stat',
+  'marimo-callout',
+  'marimo-progress',
+  'marimo-status',
+  'marimo-lazy',
+  'marimo-anywidget',
+];
+
+const MARIMO_ATTRS = [
+  'object-id',
+  'random-id',
+  'data-*',
+  'label',
+  'min',
+  'max',
+  'step',
+  'value',
+  'disabled',
+  'placeholder',
+];
+
 const htmlContent = computed(() => {
   if (!props.output) return null;
   const html = extractHtml(props.output);
-  // Sanitize HTML to prevent XSS
-  return html ? DOMPurify.sanitize(html) : null;
+  // Sanitize HTML to prevent XSS, but allow marimo's custom elements
+  return html ? DOMPurify.sanitize(html, {
+    ADD_TAGS: MARIMO_TAGS,
+    ADD_ATTR: MARIMO_ATTRS,
+    CUSTOM_ELEMENT_HANDLING: {
+      tagNameCheck: (tagName) => tagName.startsWith('marimo-'),
+      attributeNameCheck: () => true,
+      allowCustomizedBuiltInElements: true,
+    },
+  }) : null;
 });
 
 // Console array is normalized by kernel-connection.ts; this handles data field rendering

--- a/slidev-addon-marimo-live/composables/useKernelState.ts
+++ b/slidev-addon-marimo-live/composables/useKernelState.ts
@@ -137,7 +137,7 @@ export function registerNotebookCells(
   }
 
   console.log(
-    `[marimo-live] Registered ${cellIds.length} notebook cells`,
+    `[marimo-live] Registered ${cellIds.length} notebook cells:`,
     Array.from(notebookCellsByName.keys()),
   );
 }
@@ -151,8 +151,11 @@ export function getNotebookCellById(cellId: string): NotebookCell | undefined {
 
 /**
  * Get a notebook cell by name (function name in marimo)
+ * Note: Access the reactive map's size first to ensure Vue tracks this dependency
  */
 export function getNotebookCellByName(name: string): NotebookCell | undefined {
+  // Access size to create a reactive dependency (Vue tracks Map.size changes)
+  const _ = notebookCellsByName.size;
   return notebookCellsByName.get(name);
 }
 

--- a/slidev-addon-marimo-live/composables/useKernelState.ts
+++ b/slidev-addon-marimo-live/composables/useKernelState.ts
@@ -45,6 +45,8 @@ const variables = ref<VariableInfo[]>([]);
 // Global kernel state
 const isKernelReady = ref(false);
 const lastExecutionTime = ref<number>(0);
+// Version counter to trigger reactivity when notebook cells change
+const notebookCellsVersion = ref(0);
 
 /**
  * Create or get cell state
@@ -136,6 +138,9 @@ export function registerNotebookCells(
     }
   }
 
+  // Increment version to trigger reactive updates in components
+  notebookCellsVersion.value++;
+
   console.log(
     `[marimo-live] Registered ${cellIds.length} notebook cells:`,
     Array.from(notebookCellsByName.keys()),
@@ -224,6 +229,7 @@ export function useKernelState() {
     // Reactive state
     cellStates: readonly(cellStates) as ReadonlyMap<string, CellState>,
     notebookCells: readonly(notebookCells) as ReadonlyMap<string, NotebookCell>,
+    notebookCellsVersion: readonly(notebookCellsVersion),
     variables: readonly(variables),
     isKernelReady: readonly(isKernelReady),
     lastExecutionTime: readonly(lastExecutionTime),

--- a/slidev-addon-marimo-live/composables/useKernelState.ts
+++ b/slidev-addon-marimo-live/composables/useKernelState.ts
@@ -151,11 +151,13 @@ export function getNotebookCellById(cellId: string): NotebookCell | undefined {
 
 /**
  * Get a notebook cell by name (function name in marimo)
- * Note: Access the reactive map's size first to ensure Vue tracks this dependency
  */
 export function getNotebookCellByName(name: string): NotebookCell | undefined {
-  // Access size to create a reactive dependency (Vue tracks Map.size changes)
-  const _ = notebookCellsByName.size;
+  // IMPORTANT: Accessing .size creates a Vue reactive dependency on the Map.
+  // Without this line, computed properties using this function won't re-evaluate
+  // when the Map changes (e.g., when cells are registered after kernel-ready).
+  // This is a standard Vue 3 pattern for reactive Maps. Do not remove.
+  void notebookCellsByName.size;
   return notebookCellsByName.get(name);
 }
 

--- a/slidev-addon-marimo-live/composables/useMarimoKernel.ts
+++ b/slidev-addon-marimo-live/composables/useMarimoKernel.ts
@@ -52,9 +52,13 @@ export function initializeKernelListeners(kernel: KernelConnection): void {
   });
 
   // Handle kernel ready
-  kernel.onKernelReady((data: KernelReadyData) => {
-    console.log("[marimo-live] Kernel ready", data);
-    console.log("[marimo-live] Kernel ready with", data.cellIds?.length, "cells");
+  kernel.onKernelReady(async (data: KernelReadyData) => {
+    console.log(
+      "[marimo-live] Kernel ready with",
+      data.cellIds?.length,
+      "cells:",
+      data,
+    );
     setKernelReady(true);
 
     // Register notebook cells (from the .py file)
@@ -70,6 +74,16 @@ export function initializeKernelListeners(kernel: KernelConnection): void {
       for (let i = 0; i < data.cellIds.length; i++) {
         registerCell(data.cellIds[i], data.codes[i] || "");
       }
+    }
+
+    // In edit mode, auto_instantiate doesn't run cells automatically.
+    // Call instantiate() after kernel-ready to run all cells and share state.
+    try {
+      console.log("[marimo-live] Calling instantiate to run all cells...");
+      await kernel.instantiate();
+      console.log("[marimo-live] Notebook instantiated successfully");
+    } catch (err) {
+      console.warn("[marimo-live] Failed to instantiate notebook:", err);
     }
   });
 

--- a/slidev-addon-marimo-live/composables/useMarimoKernel.ts
+++ b/slidev-addon-marimo-live/composables/useMarimoKernel.ts
@@ -54,6 +54,7 @@ export function initializeKernelListeners(kernel: KernelConnection): void {
   // Handle kernel ready
   kernel.onKernelReady((data: KernelReadyData) => {
     console.log("[marimo-live] Kernel ready", data);
+    console.log("[marimo-live] Kernel ready with", data.cellIds?.length, "cells");
     setKernelReady(true);
 
     // Register notebook cells (from the .py file)

--- a/slidev-addon-marimo-live/index.ts
+++ b/slidev-addon-marimo-live/index.ts
@@ -15,6 +15,9 @@
 // Main component for live cells
 export { default as MarimoLive } from "./components/MarimoLive.vue";
 
+// Semantic alias for cell references
+export { default as MarimoCell } from "./components/MarimoCell.vue";
+
 // Output renderer component
 export { default as MarimoOutput } from "./components/MarimoOutput.vue";
 

--- a/slidev-addon-marimo-live/package.json
+++ b/slidev-addon-marimo-live/package.json
@@ -42,6 +42,7 @@
     "@biomejs/biome": "2.3.7",
     "@slidev/cli": "latest",
     "@slidev/types": "latest",
+    "@types/dompurify": "^3.2.0",
     "@vitejs/plugin-vue": "^6.0.1",
     "@vitest/ui": "^1.6.0",
     "jsdom": "^23.0.0",
@@ -66,5 +67,8 @@
   "homepage": "https://github.com/lucharo/slidev-marimo#readme",
   "bugs": {
     "url": "https://github.com/lucharo/slidev-marimo/issues"
+  },
+  "dependencies": {
+    "dompurify": "^3.3.1"
   }
 }

--- a/slidev-addon-marimo-live/scripts/start-kernel.sh
+++ b/slidev-addon-marimo-live/scripts/start-kernel.sh
@@ -114,9 +114,12 @@ echo "Press Ctrl+C to stop the server"
 echo ""
 
 # Start marimo with the required flags for Slidev integration
+# Using 'edit' mode to get cell names for referencing by name (e.g., cell="slider_demo")
+# The Slidev addon will call /api/kernel/instantiate to run all cells on connect.
 # --headless: Don't open browser
 # --port: Specify port
 # --no-token: Disable authentication (for local dev)
+# --no-skew-protection: Disable token validation for local dev
 # --allow-origins: Allow CORS from Slidev dev server
 exec marimo edit "$NOTEBOOK" \
     --headless \

--- a/slidev-addon-marimo-live/setup/kernel-connection.ts
+++ b/slidev-addon-marimo-live/setup/kernel-connection.ts
@@ -97,6 +97,7 @@ export function createKernelConnection(
   let state: ConnectionState = "disconnected";
   let reconnectAttempts = 0;
   let reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
+  let serverToken: string | null = null;
 
   // Event handlers
   const messageHandlers = new Set<(msg: MarimoMessage) => void>();
@@ -110,6 +111,27 @@ export function createKernelConnection(
     if (state !== newState) {
       state = newState;
       stateChangeHandlers.forEach((h) => h(state));
+    }
+  }
+
+  /**
+   * Fetch the skew protection token from the marimo server.
+   * This token is embedded in the HTML page and required for API requests.
+   */
+  async function fetchServerToken(): Promise<string | null> {
+    try {
+      const response = await fetch(config.httpUrl);
+      const html = await response.text();
+      const match = html.match(/data-token="([^"]+)"/);
+      if (match) {
+        console.log("[marimo-live] Obtained server token");
+        return match[1];
+      }
+      console.warn("[marimo-live] No server token found in page");
+      return null;
+    } catch (err) {
+      console.error("[marimo-live] Failed to fetch server token:", err);
+      return null;
     }
   }
 
@@ -214,6 +236,11 @@ export function createKernelConnection(
       "Marimo-Session-Id": config.sessionId,
     };
 
+    // Include server token for skew protection if available
+    if (serverToken) {
+      headers["Marimo-Server-Token"] = serverToken;
+    }
+
     const response = await fetch(url, {
       method,
       headers,
@@ -244,6 +271,9 @@ export function createKernelConnection(
       }
 
       setState("connecting");
+
+      // Fetch server token for skew protection
+      serverToken = await fetchServerToken();
 
       return new Promise<void>((resolve, reject) => {
         const wsUrl = new URL(config.wsUrl);

--- a/slidev-addon-marimo-live/setup/kernel-connection.ts
+++ b/slidev-addon-marimo-live/setup/kernel-connection.ts
@@ -349,7 +349,12 @@ export function createKernelConnection(
         throw new Error("Not connected to kernel");
       }
 
-      await httpRequest("/api/kernel/instantiate", "POST");
+      // InstantiateNotebookRequest requires objectIds and values arrays
+      // Empty arrays means instantiate all cells with their default values
+      await httpRequest("/api/kernel/instantiate", "POST", {
+        objectIds: [],
+        values: [],
+      });
     },
 
     async setUIElementValue(objectId: string, value: unknown) {

--- a/slidev-addon-marimo-live/setup/main.ts
+++ b/slidev-addon-marimo-live/setup/main.ts
@@ -31,8 +31,11 @@ const DEFAULT_KERNEL_CONFIG: KernelConfig = {
 };
 
 export default ({ app }) => {
+  console.log("[marimo-live] MAIN.TS ENTRY POINT CALLED");
+
   // Only run on client side
   if (typeof window === "undefined") {
+    console.log("[marimo-live] SKIPPING - not in browser");
     return;
   }
 
@@ -57,21 +60,33 @@ export default ({ app }) => {
 
   // Install message bridge BEFORE loading marimo frontend
   // This ensures UI component communications are intercepted
-  installMessageBridge(kernel);
+  console.log("[marimo-live] Installing message bridge...");
+  try {
+    installMessageBridge(kernel);
+    console.log("[marimo-live] Message bridge installed");
+  } catch (err) {
+    console.error("[marimo-live] Message bridge installation failed:", err);
+  }
 
   // Load marimo frontend for interactive UI components
-  loadMarimoFrontend()
-    .then(() => {
-      console.log("[marimo-live] Frontend loaded, UI components ready");
-      // Start polling for sliders and inject styles
-      pollForSliders();
-      // Also set up observer for dynamically added sliders
-      observeSliders();
-    })
-    .catch((err) => {
-      console.warn("[marimo-live] Frontend loading failed:", err);
-      console.log("[marimo-live] UI components may not render correctly");
-    });
+  console.log("[marimo-live] About to call loadMarimoFrontend()...");
+  try {
+    loadMarimoFrontend()
+      .then(() => {
+        console.log("[marimo-live] Frontend loaded, UI components ready");
+        // Start polling for sliders and inject styles
+        pollForSliders();
+        // Also set up observer for dynamically added sliders
+        observeSliders();
+      })
+      .catch((err) => {
+        console.warn("[marimo-live] Frontend loading failed:", err);
+        console.log("[marimo-live] UI components may not render correctly");
+      });
+    console.log("[marimo-live] loadMarimoFrontend() called (promise pending)");
+  } catch (err) {
+    console.error("[marimo-live] loadMarimoFrontend() threw synchronously:", err);
+  }
 
   // Provide kernel to all components
   app.provide(KERNEL_CONNECTION_KEY, kernel);

--- a/slidev-addon-marimo-live/setup/main.ts
+++ b/slidev-addon-marimo-live/setup/main.ts
@@ -54,21 +54,9 @@ export default ({ app }) => {
   // Auto-connect when the app starts
   kernel
     .connect()
-    .then(async () => {
+    .then(() => {
       console.log("[marimo-live] Connected to marimo server");
-
-      // In edit mode, auto_instantiate doesn't run cells automatically.
-      // We need to call instantiate() to run all cells and share state.
-      // Wait a bit for the kernel-ready message to be processed first.
-      setTimeout(async () => {
-        try {
-          console.log("[marimo-live] Calling instantiate to run all cells...");
-          await kernel.instantiate();
-          console.log("[marimo-live] Notebook instantiated successfully");
-        } catch (err) {
-          console.warn("[marimo-live] Failed to instantiate notebook:", err);
-        }
-      }, 500);
+      // Instantiation is now triggered by kernel-ready handler in useMarimoKernel.ts
     })
     .catch((err) => {
       console.error("[marimo-live] Failed to connect:", err);

--- a/slidev-addon-marimo-live/setup/main.ts
+++ b/slidev-addon-marimo-live/setup/main.ts
@@ -4,6 +4,10 @@
  * This file is automatically loaded by Slidev.
  * Initializes the WebSocket connection to the marimo server and provides
  * the kernel connection to all components via Vue's dependency injection.
+ *
+ * Also loads the marimo frontend for interactive UI elements (sliders,
+ * dropdowns, charts) and sets up the message bridge to redirect UI
+ * communications to the WebSocket kernel.
  */
 
 import {
@@ -11,6 +15,9 @@ import {
   KERNEL_CONNECTION_KEY,
 } from "../composables/useMarimoKernel";
 import { createKernelConnection, type KernelConfig } from "./kernel-connection";
+import { loadMarimoFrontend } from "./marimo-frontend";
+import { installMessageBridge } from "./message-bridge";
+import { observeSliders, pollForSliders } from "./slider-styles";
 import { initializeUISync } from "./ui-sync";
 
 // Default configuration - can be overridden via slidev frontmatter or global config
@@ -47,6 +54,24 @@ export default ({ app }) => {
 
   // Set up UI element synchronization
   initializeUISync(kernel);
+
+  // Install message bridge BEFORE loading marimo frontend
+  // This ensures UI component communications are intercepted
+  installMessageBridge(kernel);
+
+  // Load marimo frontend for interactive UI components
+  loadMarimoFrontend()
+    .then(() => {
+      console.log("[marimo-live] Frontend loaded, UI components ready");
+      // Start polling for sliders and inject styles
+      pollForSliders();
+      // Also set up observer for dynamically added sliders
+      observeSliders();
+    })
+    .catch((err) => {
+      console.warn("[marimo-live] Frontend loading failed:", err);
+      console.log("[marimo-live] UI components may not render correctly");
+    });
 
   // Provide kernel to all components
   app.provide(KERNEL_CONNECTION_KEY, kernel);

--- a/slidev-addon-marimo-live/setup/main.ts
+++ b/slidev-addon-marimo-live/setup/main.ts
@@ -54,8 +54,21 @@ export default ({ app }) => {
   // Auto-connect when the app starts
   kernel
     .connect()
-    .then(() => {
+    .then(async () => {
       console.log("[marimo-live] Connected to marimo server");
+
+      // In edit mode, auto_instantiate doesn't run cells automatically.
+      // We need to call instantiate() to run all cells and share state.
+      // Wait a bit for the kernel-ready message to be processed first.
+      setTimeout(async () => {
+        try {
+          console.log("[marimo-live] Calling instantiate to run all cells...");
+          await kernel.instantiate();
+          console.log("[marimo-live] Notebook instantiated successfully");
+        } catch (err) {
+          console.warn("[marimo-live] Failed to instantiate notebook:", err);
+        }
+      }, 500);
     })
     .catch((err) => {
       console.error("[marimo-live] Failed to connect:", err);

--- a/slidev-addon-marimo-live/setup/main.ts
+++ b/slidev-addon-marimo-live/setup/main.ts
@@ -31,11 +31,8 @@ const DEFAULT_KERNEL_CONFIG: KernelConfig = {
 };
 
 export default ({ app }) => {
-  console.log("[marimo-live] MAIN.TS ENTRY POINT CALLED");
-
   // Only run on client side
   if (typeof window === "undefined") {
-    console.log("[marimo-live] SKIPPING - not in browser");
     return;
   }
 
@@ -60,33 +57,20 @@ export default ({ app }) => {
 
   // Install message bridge BEFORE loading marimo frontend
   // This ensures UI component communications are intercepted
-  console.log("[marimo-live] Installing message bridge...");
-  try {
-    installMessageBridge(kernel);
-    console.log("[marimo-live] Message bridge installed");
-  } catch (err) {
-    console.error("[marimo-live] Message bridge installation failed:", err);
-  }
+  installMessageBridge(kernel);
 
   // Load marimo frontend for interactive UI components
-  console.log("[marimo-live] About to call loadMarimoFrontend()...");
-  try {
-    loadMarimoFrontend()
-      .then(() => {
-        console.log("[marimo-live] Frontend loaded, UI components ready");
-        // Start polling for sliders and inject styles
-        pollForSliders();
-        // Also set up observer for dynamically added sliders
-        observeSliders();
-      })
-      .catch((err) => {
-        console.warn("[marimo-live] Frontend loading failed:", err);
-        console.log("[marimo-live] UI components may not render correctly");
-      });
-    console.log("[marimo-live] loadMarimoFrontend() called (promise pending)");
-  } catch (err) {
-    console.error("[marimo-live] loadMarimoFrontend() threw synchronously:", err);
-  }
+  loadMarimoFrontend()
+    .then(() => {
+      console.log("[marimo-live] Frontend loaded, UI components ready");
+      // Start polling for sliders and inject styles
+      pollForSliders();
+      // Also set up observer for dynamically added sliders
+      observeSliders();
+    })
+    .catch((err) => {
+      console.warn("[marimo-live] Frontend loading failed:", err);
+    });
 
   // Provide kernel to all components
   app.provide(KERNEL_CONNECTION_KEY, kernel);

--- a/slidev-addon-marimo-live/setup/marimo-frontend.ts
+++ b/slidev-addon-marimo-live/setup/marimo-frontend.ts
@@ -211,16 +211,21 @@ export async function waitForCustomElement(
  * @returns Promise that resolves when frontend is loaded
  */
 export async function loadMarimoFrontend(): Promise<void> {
+  console.log("[marimo-live] loadMarimoFrontend() CALLED");
+
   // Return existing promise if already loading
   if (loadPromise) {
+    console.log("[marimo-live] loadMarimoFrontend() returning existing promise");
     return loadPromise;
   }
 
   // Already loaded
   if (isLoaded) {
+    console.log("[marimo-live] loadMarimoFrontend() already loaded");
     return Promise.resolve();
   }
 
+  console.log("[marimo-live] loadMarimoFrontend() starting load");
   isLoading = true;
 
   loadPromise = (async () => {

--- a/slidev-addon-marimo-live/setup/marimo-frontend.ts
+++ b/slidev-addon-marimo-live/setup/marimo-frontend.ts
@@ -10,7 +10,9 @@
  */
 
 // Match the marimo-islands version used by marimo server
-// Note: This is a dev version; update when stable release is available
+// TODO: Update to stable release when available
+// See: https://github.com/marimo-team/marimo/releases
+// Note: Dev versions may be removed from CDN
 const MARIMO_VERSION = "0.19.8-dev4";
 
 // Track loading state
@@ -145,14 +147,11 @@ function loadPrism(): void {
   if (typeof document === "undefined") return;
   if (document.getElementById("marimo-live-prism")) return;
 
-  // Choose theme based on dark mode
-  const isDarkMode = document.documentElement.classList.contains("dark");
+  // Use dark theme for code blocks (matches One Dark styling in component)
   const prismCss = document.createElement("link");
   prismCss.id = "marimo-live-prism";
   prismCss.rel = "stylesheet";
-  prismCss.href = isDarkMode
-    ? "https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css"
-    : "https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css"; // Use dark theme for code blocks
+  prismCss.href = "https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css";
   document.head.appendChild(prismCss);
 
   // Load Prism core

--- a/slidev-addon-marimo-live/setup/marimo-frontend.ts
+++ b/slidev-addon-marimo-live/setup/marimo-frontend.ts
@@ -211,21 +211,16 @@ export async function waitForCustomElement(
  * @returns Promise that resolves when frontend is loaded
  */
 export async function loadMarimoFrontend(): Promise<void> {
-  console.log("[marimo-live] loadMarimoFrontend() CALLED");
-
   // Return existing promise if already loading
   if (loadPromise) {
-    console.log("[marimo-live] loadMarimoFrontend() returning existing promise");
     return loadPromise;
   }
 
   // Already loaded
   if (isLoaded) {
-    console.log("[marimo-live] loadMarimoFrontend() already loaded");
     return Promise.resolve();
   }
 
-  console.log("[marimo-live] loadMarimoFrontend() starting load");
   isLoading = true;
 
   loadPromise = (async () => {

--- a/slidev-addon-marimo-live/setup/marimo-frontend.ts
+++ b/slidev-addon-marimo-live/setup/marimo-frontend.ts
@@ -1,0 +1,281 @@
+/**
+ * Marimo Frontend Loader
+ *
+ * Loads the marimo islands frontend from CDN to enable interactive UI elements
+ * like sliders, dropdowns, and charts. The frontend defines custom elements
+ * (marimo-slider, marimo-dropdown, etc.) that render and handle user interactions.
+ *
+ * This module should be called AFTER the message bridge is installed so that
+ * UI component communications are properly intercepted and routed to WebSocket.
+ */
+
+// Match the marimo-islands version used by marimo server
+// Note: This is a dev version; update when stable release is available
+const MARIMO_VERSION = "0.19.8-dev4";
+
+// Track loading state
+let isLoading = false;
+let isLoaded = false;
+let loadPromise: Promise<void> | null = null;
+
+/**
+ * Load marimo frontend CSS from CDN.
+ * Adds the stylesheet to document head if not already present.
+ */
+function loadMarimoCSS(): void {
+  if (typeof document === "undefined") return;
+  if (document.getElementById("marimo-live-css")) return;
+
+  const link = document.createElement("link");
+  link.id = "marimo-live-css";
+  link.rel = "stylesheet";
+  link.href = `https://cdn.jsdelivr.net/npm/@marimo-team/islands@${MARIMO_VERSION}/dist/style.css`;
+  link.crossOrigin = "anonymous";
+  link.onerror = () => {
+    console.error("[marimo-live] Failed to load marimo CSS from CDN");
+  };
+  document.head.appendChild(link);
+  console.log("[marimo-live] Marimo CSS loaded");
+}
+
+/**
+ * Load marimo frontend JavaScript from CDN.
+ * The script defines all marimo custom elements.
+ * Returns a promise that resolves when the script is loaded.
+ */
+function loadMarimoScript(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (typeof document === "undefined") {
+      reject(new Error("Not in browser environment"));
+      return;
+    }
+
+    if (document.getElementById("marimo-live-script")) {
+      resolve();
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.id = "marimo-live-script";
+    script.type = "module";
+    script.src = `https://cdn.jsdelivr.net/npm/@marimo-team/islands@${MARIMO_VERSION}/dist/main.js`;
+
+    script.onload = () => {
+      console.log(`[marimo-live] Marimo script loaded (v${MARIMO_VERSION})`);
+      resolve();
+    };
+
+    script.onerror = () => {
+      const error = new Error("Failed to load marimo script from CDN");
+      console.error("[marimo-live]", error.message);
+      reject(error);
+    };
+
+    document.head.appendChild(script);
+  });
+}
+
+/**
+ * Add required marimo meta elements to the document.
+ * These are needed by the marimo frontend for proper initialization.
+ */
+function addMarimoMetaElements(): void {
+  if (typeof document === "undefined") return;
+
+  // Required marimo-filename tag
+  if (!document.querySelector("marimo-filename")) {
+    const marimoFilename = document.createElement("marimo-filename");
+    marimoFilename.hidden = true;
+    document.head.appendChild(marimoFilename);
+  }
+
+  // Required marimo-mode tag (set to "read" for presentation mode)
+  if (!document.querySelector("marimo-mode")) {
+    const marimoMode = document.createElement("marimo-mode");
+    marimoMode.setAttribute("data-mode", "read");
+    marimoMode.hidden = true;
+    document.head.appendChild(marimoMode);
+  }
+}
+
+/**
+ * Load additional fonts and resources used by marimo.
+ */
+function loadFontsAndResources(): void {
+  if (typeof document === "undefined") return;
+  if (document.getElementById("marimo-live-fonts")) return;
+
+  // Google Fonts preconnect
+  const preconnect1 = document.createElement("link");
+  preconnect1.id = "marimo-live-fonts";
+  preconnect1.rel = "preconnect";
+  preconnect1.href = "https://fonts.googleapis.com";
+  document.head.appendChild(preconnect1);
+
+  const preconnect2 = document.createElement("link");
+  preconnect2.rel = "preconnect";
+  preconnect2.href = "https://fonts.gstatic.com";
+  preconnect2.crossOrigin = "anonymous";
+  document.head.appendChild(preconnect2);
+
+  // Fonts used by marimo UI
+  const fonts = document.createElement("link");
+  fonts.rel = "stylesheet";
+  fonts.href =
+    "https://fonts.googleapis.com/css2?family=Fira+Mono:wght@400;500;700&family=Lora&family=PT+Sans:wght@400;700&display=swap";
+  document.head.appendChild(fonts);
+
+  // KaTeX CSS for math rendering
+  const katex = document.createElement("link");
+  katex.rel = "stylesheet";
+  katex.href = "https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css";
+  katex.integrity =
+    "sha384-wcIxkf4k558AjM3Yz3BBFQUbk/zgIYC2R0QpeeYb+TwlBVMrlgLqwRjRtGZiK7ww";
+  katex.crossOrigin = "anonymous";
+  document.head.appendChild(katex);
+
+  // Load Prism.js for syntax highlighting
+  loadPrism();
+}
+
+/**
+ * Load Prism.js for Python syntax highlighting.
+ */
+function loadPrism(): void {
+  if (typeof document === "undefined") return;
+  if (document.getElementById("marimo-live-prism")) return;
+
+  // Choose theme based on dark mode
+  const isDarkMode = document.documentElement.classList.contains("dark");
+  const prismCss = document.createElement("link");
+  prismCss.id = "marimo-live-prism";
+  prismCss.rel = "stylesheet";
+  prismCss.href = isDarkMode
+    ? "https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css"
+    : "https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css"; // Use dark theme for code blocks
+  document.head.appendChild(prismCss);
+
+  // Load Prism core
+  const prismJs = document.createElement("script");
+  prismJs.src = "https://cdn.jsdelivr.net/npm/prismjs@1.29.0/prism.min.js";
+  prismJs.onload = () => {
+    // Load Python language component after core is ready
+    const prismPython = document.createElement("script");
+    prismPython.src =
+      "https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-python.min.js";
+    prismPython.onload = () => {
+      // Dispatch event so components know Prism is fully ready
+      window.dispatchEvent(new Event("prism-ready"));
+      console.log("[marimo-live] Prism.js loaded with Python support");
+    };
+    document.head.appendChild(prismPython);
+  };
+  document.head.appendChild(prismJs);
+}
+
+/**
+ * Wait for a specific custom element to be defined.
+ * Useful for ensuring UI components are ready.
+ *
+ * @param tagName - The custom element tag name (e.g., "marimo-slider")
+ * @param timeout - Maximum time to wait in ms (default: 30000)
+ */
+export async function waitForCustomElement(
+  tagName: string,
+  timeout = 30000,
+): Promise<void> {
+  if (typeof customElements === "undefined") {
+    throw new Error("CustomElements API not available");
+  }
+
+  // Check if already defined
+  if (customElements.get(tagName)) {
+    return;
+  }
+
+  // Wait for definition with timeout
+  return Promise.race([
+    customElements.whenDefined(tagName),
+    new Promise<void>((_, reject) =>
+      setTimeout(() => reject(new Error(`Timeout waiting for ${tagName}`)), timeout)
+    ),
+  ]);
+}
+
+/**
+ * Load the marimo frontend resources (CSS, JS, fonts).
+ * This is the main entry point for loading the marimo UI system.
+ *
+ * The function is idempotent - calling it multiple times will only load once.
+ * It returns a promise that resolves when the frontend is ready.
+ *
+ * @returns Promise that resolves when frontend is loaded
+ */
+export async function loadMarimoFrontend(): Promise<void> {
+  // Return existing promise if already loading
+  if (loadPromise) {
+    return loadPromise;
+  }
+
+  // Already loaded
+  if (isLoaded) {
+    return Promise.resolve();
+  }
+
+  isLoading = true;
+
+  loadPromise = (async () => {
+    try {
+      // Add meta elements first
+      addMarimoMetaElements();
+
+      // Load resources in parallel
+      loadFontsAndResources();
+      loadMarimoCSS();
+
+      // Load and wait for script
+      await loadMarimoScript();
+
+      // Wait for at least one custom element to be defined
+      // This ensures the marimo frontend has initialized
+      try {
+        await waitForCustomElement("marimo-slider", 10000);
+        console.log("[marimo-live] Custom elements ready");
+      } catch {
+        // Not all pages may have sliders; this is not fatal
+        console.debug("[marimo-live] marimo-slider not defined yet (may be normal)");
+      }
+
+      isLoaded = true;
+      isLoading = false;
+      console.log("[marimo-live] Frontend loaded successfully");
+    } catch (error) {
+      isLoading = false;
+      loadPromise = null;
+      throw error;
+    }
+  })();
+
+  return loadPromise;
+}
+
+/**
+ * Check if the marimo frontend has been loaded.
+ */
+export function isMarimoFrontendLoaded(): boolean {
+  return isLoaded;
+}
+
+/**
+ * Check if the marimo frontend is currently loading.
+ */
+export function isMarimoFrontendLoading(): boolean {
+  return isLoading;
+}
+
+/**
+ * Get the marimo version being used.
+ */
+export function getMarimoVersion(): string {
+  return MARIMO_VERSION;
+}

--- a/slidev-addon-marimo-live/setup/message-bridge.ts
+++ b/slidev-addon-marimo-live/setup/message-bridge.ts
@@ -1,0 +1,314 @@
+/**
+ * Message Bridge
+ *
+ * Intercepts marimo UI component communications and redirects them to the
+ * WebSocket kernel connection. This bridges the gap between marimo's frontend
+ * (which expects a Pyodide bridge) and our live kernel backend.
+ *
+ * The Problem:
+ * marimo-islands frontend uses window._marimo_private_IslandsPyodideBridge
+ * to communicate with a Pyodide kernel. In our case, we have a WebSocket
+ * connection to a live marimo server, so we need to intercept these calls.
+ *
+ * The Solution:
+ * Install a property trap that intercepts when marimo creates the bridge,
+ * then patch the bridge methods to forward requests to our WebSocket kernel.
+ */
+
+import type { KernelConnection } from "./kernel-connection";
+
+// Type for the bridge interface
+interface IslandsBridge {
+  putControlRequest: (request: ControlRequest) => Promise<unknown>;
+  sendComponentValues?: (request: ControlRequest) => Promise<unknown>;
+  [key: string]: unknown;
+}
+
+// Type for control request messages
+interface ControlRequest {
+  type?: string;
+  objectIds?: string[];
+  values?: unknown[];
+  object_id?: string;
+  value?: unknown;
+  updates?: Array<{ object_id: string; value: unknown }>;
+  [key: string]: unknown;
+}
+
+// Track bridge installation state
+let bridgeInstalled = false;
+let bridgeTrapInstalled = false;
+let kernelRef: KernelConnection | null = null;
+
+/**
+ * Determine the message type based on the request structure.
+ * Maps request shapes to their expected type discriminator values.
+ */
+function inferMessageType(request: ControlRequest): string | null {
+  // UI element value update: has objectIds and values arrays
+  if (Array.isArray(request.objectIds) && Array.isArray(request.values)) {
+    return "update-ui-element";
+  }
+
+  // Component values update: singular object_id with value
+  if ("object_id" in request && "value" in request) {
+    return "update-ui-element";
+  }
+
+  // Batch component values: array of updates
+  if (Array.isArray(request.updates)) {
+    return "update-ui-element";
+  }
+
+  // Generic values payload
+  if ("values" in request && !("objectIds" in request)) {
+    return "update-ui-element";
+  }
+
+  return null;
+}
+
+/**
+ * Process a control request and send it to the WebSocket kernel.
+ */
+async function handleControlRequest(request: ControlRequest): Promise<unknown> {
+  if (!kernelRef) {
+    console.warn("[marimo-live] Bridge: kernel not available, ignoring request");
+    return null;
+  }
+
+  if (!kernelRef.isConnected) {
+    console.warn("[marimo-live] Bridge: kernel not connected, ignoring request");
+    return null;
+  }
+
+  // Handle array format: objectIds and values
+  if (Array.isArray(request.objectIds) && Array.isArray(request.values)) {
+    const results: unknown[] = [];
+    for (let i = 0; i < request.objectIds.length; i++) {
+      const objectId = request.objectIds[i];
+      const value = request.values[i];
+      try {
+        await kernelRef.setUIElementValue(objectId, value);
+        console.log(`[marimo-live] Bridge: UI update sent ${objectId}`, value);
+        results.push({ success: true, objectId });
+      } catch (err) {
+        console.error(`[marimo-live] Bridge: failed to update ${objectId}`, err);
+        results.push({ success: false, objectId, error: err });
+      }
+    }
+    return results;
+  }
+
+  // Handle singular format: object_id and value
+  if ("object_id" in request && "value" in request) {
+    const objectId = request.object_id as string;
+    const value = request.value;
+    try {
+      await kernelRef.setUIElementValue(objectId, value);
+      console.log(`[marimo-live] Bridge: UI update sent ${objectId}`, value);
+      return { success: true };
+    } catch (err) {
+      console.error(`[marimo-live] Bridge: failed to update ${objectId}`, err);
+      return { success: false, error: err };
+    }
+  }
+
+  // Handle batch format: updates array
+  if (Array.isArray(request.updates)) {
+    const results: unknown[] = [];
+    for (const update of request.updates) {
+      try {
+        await kernelRef.setUIElementValue(update.object_id, update.value);
+        console.log(`[marimo-live] Bridge: UI update sent ${update.object_id}`, update.value);
+        results.push({ success: true, objectId: update.object_id });
+      } catch (err) {
+        console.error(`[marimo-live] Bridge: failed to update ${update.object_id}`, err);
+        results.push({ success: false, objectId: update.object_id, error: err });
+      }
+    }
+    return results;
+  }
+
+  console.warn("[marimo-live] Bridge: unknown request format", request);
+  return null;
+}
+
+/**
+ * Patch an existing bridge object to intercept its methods.
+ */
+function patchBridge(bridge: IslandsBridge): void {
+  if (bridgeInstalled) return;
+
+  // Store original methods
+  const originalPutControl = bridge.putControlRequest?.bind(bridge);
+  const originalSendValues = bridge.sendComponentValues?.bind(bridge);
+
+  // Patch putControlRequest
+  if (originalPutControl) {
+    bridge.putControlRequest = async (request: ControlRequest) => {
+      console.debug("[marimo-live] Bridge: intercepted putControlRequest", request);
+
+      // Add missing type field if needed (marimo bug workaround)
+      if (!request.type) {
+        const inferredType = inferMessageType(request);
+        if (inferredType) {
+          request = { type: inferredType, ...request };
+        }
+      }
+
+      // Forward to WebSocket kernel
+      const result = await handleControlRequest(request);
+
+      // Also call original if it exists (for any local handling)
+      // But wrap in try-catch as it may fail without Pyodide
+      try {
+        if (typeof originalPutControl === "function") {
+          await originalPutControl(request);
+        }
+      } catch {
+        // Expected to fail in live mode - Pyodide not available
+      }
+
+      return result;
+    };
+    console.log("[marimo-live] Bridge: patched putControlRequest");
+  }
+
+  // Patch sendComponentValues if it exists
+  if (originalSendValues) {
+    bridge.sendComponentValues = async (request: ControlRequest) => {
+      console.debug("[marimo-live] Bridge: intercepted sendComponentValues", request);
+      return handleControlRequest(request);
+    };
+    console.log("[marimo-live] Bridge: patched sendComponentValues");
+  }
+
+  bridgeInstalled = true;
+  console.log("[marimo-live] Bridge: installation complete");
+}
+
+/**
+ * Install a property trap to intercept when marimo creates the bridge.
+ * This ensures we can patch the bridge methods as soon as they're available.
+ */
+function installBridgeTrap(): void {
+  if (bridgeTrapInstalled) return;
+  if (typeof window === "undefined") return;
+
+  const BRIDGE_KEY = "_marimo_private_IslandsPyodideBridge";
+  const win = window as unknown as Record<string, unknown>;
+
+  // Check if bridge already exists
+  if (win[BRIDGE_KEY]) {
+    console.log("[marimo-live] Bridge: already exists, patching now");
+    patchBridge(win[BRIDGE_KEY] as IslandsBridge);
+    bridgeTrapInstalled = true;
+    return;
+  }
+
+  let _bridge: IslandsBridge | undefined = undefined;
+
+  Object.defineProperty(window, BRIDGE_KEY, {
+    configurable: true,
+    enumerable: true,
+    get() {
+      return _bridge;
+    },
+    set(newBridge: IslandsBridge) {
+      console.log("[marimo-live] Bridge: created, intercepting...");
+      _bridge = newBridge;
+
+      // Patch synchronously when bridge is created
+      if (newBridge) {
+        patchBridge(newBridge);
+      }
+    },
+  });
+
+  bridgeTrapInstalled = true;
+  console.log("[marimo-live] Bridge: trap installed");
+}
+
+/**
+ * Poll for the bridge to become available.
+ * Fallback if the trap doesn't catch it.
+ */
+function pollForBridge(maxAttempts = 100, interval = 50): void {
+  const BRIDGE_KEY = "_marimo_private_IslandsPyodideBridge";
+  let attempts = 0;
+
+  const check = () => {
+    attempts++;
+    const win = window as unknown as Record<string, unknown>;
+    const bridge = win[BRIDGE_KEY] as IslandsBridge | undefined;
+
+    if (bridge && !bridgeInstalled) {
+      console.log(`[marimo-live] Bridge: found via polling (attempt ${attempts})`);
+      patchBridge(bridge);
+      return;
+    }
+
+    if (attempts < maxAttempts && !bridgeInstalled) {
+      setTimeout(check, interval);
+    } else if (!bridgeInstalled) {
+      console.debug("[marimo-live] Bridge: polling complete, bridge not found");
+    }
+  };
+
+  setTimeout(check, interval);
+}
+
+/**
+ * Install the message bridge to intercept marimo UI communications.
+ * This should be called BEFORE loading the marimo frontend.
+ *
+ * @param kernel - The WebSocket kernel connection to use
+ */
+export function installMessageBridge(kernel: KernelConnection): void {
+  if (typeof window === "undefined") {
+    console.warn("[marimo-live] Bridge: not in browser environment");
+    return;
+  }
+
+  // Store kernel reference for request handling
+  kernelRef = kernel;
+
+  // Install trap before bridge is created
+  installBridgeTrap();
+
+  // Also poll as fallback
+  pollForBridge();
+
+  console.log("[marimo-live] Bridge: initialized");
+}
+
+/**
+ * Check if the message bridge is installed.
+ */
+export function isMessageBridgeInstalled(): boolean {
+  return bridgeInstalled;
+}
+
+/**
+ * Check if the bridge trap is installed.
+ */
+export function isBridgeTrapInstalled(): boolean {
+  return bridgeTrapInstalled;
+}
+
+/**
+ * Reset bridge state (for testing or HMR).
+ */
+export function resetMessageBridge(): void {
+  bridgeInstalled = false;
+  bridgeTrapInstalled = false;
+  kernelRef = null;
+  console.log("[marimo-live] Bridge: reset");
+}
+
+// HMR: Force full page reload when this file changes
+// Bridge state cannot be hot-reloaded
+if (import.meta.hot) {
+  import.meta.hot.decline();
+}

--- a/slidev-addon-marimo-live/setup/preparser.ts
+++ b/slidev-addon-marimo-live/setup/preparser.ts
@@ -18,6 +18,26 @@
 
 import { definePreparserSetup } from "@slidev/types";
 
+/**
+ * Format a flag key-value pair for use in a Vue component tag.
+ * Handles special cases like boolean values and kebab-case conversions.
+ */
+function formatFlag(key: string, value: string): string {
+  if (value === "true" || value === "false") {
+    return ` :${key}="${value}"`;
+  }
+  if (key === "hideLines") {
+    return ` :hide-lines="${value}"`;
+  }
+  if (key === "codePosition") {
+    return ` code-position="${value}"`;
+  }
+  if (key === "cellId") {
+    return ` cell-id="${value}"`;
+  }
+  return ` ${key}="${value}"`;
+}
+
 export default definePreparserSetup(() => {
   return [
     {
@@ -60,24 +80,20 @@ export default definePreparserSetup(() => {
 
             // Handle cell references (deprecated - prefer <MarimoCell> component)
             if (flags.cell) {
+              // Log deprecation warning at build time
+              console.warn(
+                `[slidev-marimo-live] Deprecated: Use <MarimoCell cell="${flags.cell}" /> instead of \`\`\`marimo-live cell=${flags.cell}`
+              );
+
               // Backward compatibility: convert to MarimoCell component
               componentTag = `<MarimoCell cell="${flags.cell}"`;
 
               // Add other flags (excluding cell which is already handled)
               for (const [key, value] of Object.entries(flags)) {
                 if (key === "cell") continue;
-                if (value === "true" || value === "false") {
-                  componentTag += ` :${key}="${value}"`;
-                } else {
-                  componentTag += ` ${key}="${value}"`;
-                }
+                componentTag += formatFlag(key, value);
               }
               componentTag += " />";
-
-              // Add deprecation comment
-              result.push(
-                `<!-- DEPRECATED: Use <MarimoCell cell="${flags.cell}" /> instead of code fence syntax -->`
-              );
             } else if (code) {
               // Inline code - use MarimoLive
               const escapedCode = code
@@ -87,17 +103,7 @@ export default definePreparserSetup(() => {
 
               // Add flags
               for (const [key, value] of Object.entries(flags)) {
-                if (value === "true" || value === "false") {
-                  componentTag += ` :${key}="${value}"`;
-                } else if (key === "hideLines") {
-                  componentTag += ` :hide-lines="${value}"`;
-                } else if (key === "codePosition") {
-                  componentTag += ` code-position="${value}"`;
-                } else if (key === "cellId") {
-                  componentTag += ` cell-id="${value}"`;
-                } else {
-                  componentTag += ` ${key}="${value}"`;
-                }
+                componentTag += formatFlag(key, value);
               }
               componentTag += " />";
             } else {

--- a/slidev-addon-marimo-live/setup/preparser.ts
+++ b/slidev-addon-marimo-live/setup/preparser.ts
@@ -82,7 +82,7 @@ export default definePreparserSetup(() => {
             if (flags.cell) {
               // Log deprecation warning at build time
               console.warn(
-                `[slidev-marimo-live] Deprecated: Use <MarimoCell cell="${flags.cell}" /> instead of \`\`\`marimo-live cell=${flags.cell}`
+                `[slidev-marimo-live] Deprecated: Use <MarimoCell cell="${flags.cell}" /> instead of \`\`\`marimo-live cell=${flags.cell}\`\`\``
               );
 
               // Backward compatibility: convert to MarimoCell component

--- a/slidev-addon-marimo-live/setup/preparser.ts
+++ b/slidev-addon-marimo-live/setup/preparser.ts
@@ -55,34 +55,55 @@ export default definePreparserSetup(() => {
               });
             }
 
-            // Build component tag - inline code only
             const code = codeLines.join("\n").trimEnd();
-            if (!code) {
-              // Empty code block - skip it
+            let componentTag: string;
+
+            // Handle cell references (deprecated - prefer <MarimoCell> component)
+            if (flags.cell) {
+              // Backward compatibility: convert to MarimoCell component
+              componentTag = `<MarimoCell cell="${flags.cell}"`;
+
+              // Add other flags (excluding cell which is already handled)
+              for (const [key, value] of Object.entries(flags)) {
+                if (key === "cell") continue;
+                if (value === "true" || value === "false") {
+                  componentTag += ` :${key}="${value}"`;
+                } else {
+                  componentTag += ` ${key}="${value}"`;
+                }
+              }
+              componentTag += " />";
+
+              // Add deprecation comment
+              result.push(
+                `<!-- DEPRECATED: Use <MarimoCell cell="${flags.cell}" /> instead of code fence syntax -->`
+              );
+            } else if (code) {
+              // Inline code - use MarimoLive
+              const escapedCode = code
+                .replace(/"/g, "&quot;")
+                .replace(/\n/g, "&#10;");
+              componentTag = `<MarimoLive code="${escapedCode}"`;
+
+              // Add flags
+              for (const [key, value] of Object.entries(flags)) {
+                if (value === "true" || value === "false") {
+                  componentTag += ` :${key}="${value}"`;
+                } else if (key === "hideLines") {
+                  componentTag += ` :hide-lines="${value}"`;
+                } else if (key === "codePosition") {
+                  componentTag += ` code-position="${value}"`;
+                } else if (key === "cellId") {
+                  componentTag += ` cell-id="${value}"`;
+                } else {
+                  componentTag += ` ${key}="${value}"`;
+                }
+              }
+              componentTag += " />";
+            } else {
+              // Empty code block with no cell reference - skip
               continue;
             }
-
-            const escapedCode = code
-              .replace(/"/g, "&quot;")
-              .replace(/\n/g, "&#10;");
-            let componentTag = `<MarimoLive code="${escapedCode}"`;
-
-            // Add flags
-            for (const [key, value] of Object.entries(flags)) {
-              if (value === "true" || value === "false") {
-                componentTag += ` :${key}="${value}"`;
-              } else if (key === "hideLines") {
-                componentTag += ` :hide-lines="${value}"`;
-              } else if (key === "codePosition") {
-                componentTag += ` code-position="${value}"`;
-              } else if (key === "cellId") {
-                componentTag += ` cell-id="${value}"`;
-              } else {
-                componentTag += ` ${key}="${value}"`;
-              }
-            }
-
-            componentTag += " />";
 
             // Add the MarimoLive component
             result.push(componentTag);

--- a/slidev-addon-marimo-live/setup/preparser.ts
+++ b/slidev-addon-marimo-live/setup/preparser.ts
@@ -1,29 +1,19 @@
 /**
  * Preparser for marimo-live code blocks
  *
- * Transforms markdown code blocks with 'marimo-live' language tag into <MarimoLive> components
+ * Transforms markdown code blocks with 'marimo-live' language tag into <MarimoLive> components.
+ * This is only for INLINE CODE - not recommended. Use <MarimoCell> component instead.
  *
- * Example 1: Reference a notebook cell by name
- * ```marimo-live cell=plot_chart
- * ```
- *
- * Example 2: Reference a notebook cell by index
- * ```marimo-live cell=2
- * ```
- *
- * Example 3: Inline code (less recommended)
+ * Example: Inline code (not recommended - prefer <MarimoCell> component)
  * ```marimo-live
  * import pandas as pd
  * df = pd.read_csv('data.csv')
  * df.head()
  * ```
  *
- * Supported flags:
- * - cell=name: Reference a notebook cell by name, ID, or index
- * - displayCode=false: Hide the code editor
- * - autoRun=true: Run code automatically on mount
- * - codePosition=top: Show code above output
- * - cellId=my_cell: Use a specific cell ID (only with inline code)
+ * For referencing notebook cells, use the <MarimoCell> component syntax:
+ * <MarimoCell cell="plot_chart" />
+ * <MarimoCell cell="2" :displayCode="false" />
  */
 
 import { definePreparserSetup } from "@slidev/types";
@@ -55,7 +45,7 @@ export default definePreparserSetup(() => {
             // i now points to the closing ```, skip it
             i++;
 
-            // Parse flags first to check for cell reference
+            // Parse flags
             const flags: Record<string, string> = {};
             if (flagsString.trim()) {
               const flagMatches = flagsString.match(/(\w+)=([^\s]+)/g) || [];
@@ -65,34 +55,20 @@ export default definePreparserSetup(() => {
               });
             }
 
-            // Build component tag
-            let componentTag = "<MarimoLive";
-
-            // If cell reference is provided, use it instead of inline code
-            if (flags.cell) {
-              componentTag += ` cell="${flags.cell}"`;
-
-              // If there's also inline code, include it as fallback
-              const code = codeLines.join("\n").trimEnd();
-              if (code) {
-                const escapedCode = code
-                  .replace(/"/g, "&quot;")
-                  .replace(/\n/g, "&#10;");
-                componentTag += ` code="${escapedCode}"`;
-              }
-            } else {
-              // No cell reference - use inline code
-              const code = codeLines.join("\n").trimEnd();
-              const escapedCode = code
-                .replace(/"/g, "&quot;")
-                .replace(/\n/g, "&#10;");
-              componentTag += ` code="${escapedCode}"`;
+            // Build component tag - inline code only
+            const code = codeLines.join("\n").trimEnd();
+            if (!code) {
+              // Empty code block - skip it
+              continue;
             }
 
-            // Add other flags
-            for (const [key, value] of Object.entries(flags)) {
-              if (key === "cell") continue; // Already handled
+            const escapedCode = code
+              .replace(/"/g, "&quot;")
+              .replace(/\n/g, "&#10;");
+            let componentTag = `<MarimoLive code="${escapedCode}"`;
 
+            // Add flags
+            for (const [key, value] of Object.entries(flags)) {
               if (value === "true" || value === "false") {
                 componentTag += ` :${key}="${value}"`;
               } else if (key === "hideLines") {

--- a/slidev-addon-marimo-live/setup/slider-styles.ts
+++ b/slidev-addon-marimo-live/setup/slider-styles.ts
@@ -1,0 +1,280 @@
+/**
+ * Slider Styles
+ *
+ * Marimo sliders use shadow DOM which isolates them from global styles.
+ * This module injects CSS directly into slider shadow roots to ensure
+ * they render correctly and match the presentation theme.
+ *
+ * The problem: Shadow DOM encapsulation prevents external CSS from styling
+ * the slider internals. Marimo's bundled styles may not load correctly
+ * or may conflict with Slidev's styles.
+ *
+ * The solution: Poll for slider elements, wait for their shadow roots
+ * to be created, then inject CSS directly into each shadow root.
+ */
+
+// Track styling state
+let pollingStarted = false;
+let pollingInterval: ReturnType<typeof setInterval> | null = null;
+let styledSliders = new WeakSet<HTMLElement>();
+
+/**
+ * CSS styles to inject into slider shadow roots.
+ * Uses CSS custom properties for theme compatibility.
+ */
+const SLIDER_STYLES = `
+/* Horizontal slider container */
+[data-orientation="horizontal"] {
+  width: 200px !important;
+  display: flex !important;
+  align-items: center !important;
+  position: relative !important;
+}
+
+/* Slider track */
+[data-testid="track"] {
+  width: 100% !important;
+  height: 8px !important;
+  background-color: var(--ring, #64748b) !important;
+  border-radius: 9999px !important;
+  position: relative !important;
+}
+
+/* Filled range (left side of thumb) */
+[data-testid="range"] {
+  height: 100% !important;
+  background-color: var(--primary, #3b82f6) !important;
+  border-radius: 9999px !important;
+  position: absolute !important;
+  left: 0 !important;
+}
+
+/* Slider thumb (draggable handle) */
+[data-testid="thumb"] {
+  width: 16px !important;
+  height: 16px !important;
+  background-color: var(--background, white) !important;
+  border: 2px solid var(--primary, #3b82f6) !important;
+  border-radius: 50% !important;
+  cursor: pointer !important;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2) !important;
+  transition: transform 0.1s ease !important;
+}
+
+[data-testid="thumb"]:hover {
+  transform: scale(1.1) !important;
+}
+
+[data-testid="thumb"]:active {
+  transform: scale(0.95) !important;
+}
+
+[data-testid="thumb"]:focus {
+  outline: 2px solid var(--primary, #3b82f6) !important;
+  outline-offset: 2px !important;
+}
+
+/* Vertical slider orientation */
+[data-orientation="vertical"] {
+  height: 200px !important;
+  width: 20px !important;
+  display: flex !important;
+  flex-direction: column !important;
+  align-items: center !important;
+}
+
+/* Dark mode support - uses CSS custom properties */
+`;
+
+/**
+ * Inject styles into a single slider's shadow root.
+ *
+ * @param slider - The marimo-slider element
+ * @returns true if styles were injected, false if already styled or no shadow root
+ */
+function injectSliderStyles(slider: HTMLElement): boolean {
+  // Skip if already styled
+  if (styledSliders.has(slider)) {
+    return false;
+  }
+
+  const shadowRoot = slider.shadowRoot;
+  if (!shadowRoot) {
+    return false;
+  }
+
+  // Check if our styles are already present
+  if (shadowRoot.querySelector("#marimo-live-slider-styles")) {
+    styledSliders.add(slider);
+    return false;
+  }
+
+  // Create and inject style element
+  const style = document.createElement("style");
+  style.id = "marimo-live-slider-styles";
+  style.textContent = SLIDER_STYLES;
+  shadowRoot.appendChild(style);
+
+  styledSliders.add(slider);
+  return true;
+}
+
+/**
+ * Find and style all marimo-slider elements on the page.
+ *
+ * @returns Number of newly styled sliders
+ */
+export function injectAllSliderStyles(): number {
+  if (typeof document === "undefined") return 0;
+
+  const sliders = document.querySelectorAll("marimo-slider");
+  let injectedCount = 0;
+
+  sliders.forEach((slider) => {
+    if (injectSliderStyles(slider as HTMLElement)) {
+      injectedCount++;
+    }
+  });
+
+  if (injectedCount > 0) {
+    console.log(`[marimo-live] Styled ${injectedCount} slider(s)`);
+  }
+
+  return injectedCount;
+}
+
+/**
+ * Poll for slider elements and inject styles when ready.
+ * Handles lazy-loaded sliders that may appear after initial page load.
+ *
+ * @param maxAttempts - Maximum polling attempts (default: 40 = 20 seconds)
+ * @param intervalMs - Milliseconds between attempts (default: 500)
+ */
+export function pollForSliders(maxAttempts = 40, intervalMs = 500): void {
+  // Prevent multiple polling loops
+  if (pollingStarted) {
+    return;
+  }
+
+  pollingStarted = true;
+  let attempts = 0;
+  let lastSliderCount = 0;
+
+  const check = () => {
+    attempts++;
+
+    const sliders = document.querySelectorAll("marimo-slider");
+    const currentCount = sliders.length;
+
+    if (currentCount > 0) {
+      // Count sliders with shadow roots
+      const slidersWithShadowRoots = Array.from(sliders).filter(
+        (s) => (s as HTMLElement).shadowRoot
+      );
+
+      if (slidersWithShadowRoots.length > 0) {
+        const injected = injectAllSliderStyles();
+
+        // If we found new sliders, reset attempt counter
+        if (currentCount > lastSliderCount || injected > 0) {
+          lastSliderCount = currentCount;
+          attempts = Math.max(0, attempts - 10); // Give more time for new sliders
+        }
+      }
+    }
+
+    // Continue polling if under max attempts
+    if (attempts < maxAttempts) {
+      setTimeout(check, intervalMs);
+    } else {
+      pollingStarted = false;
+      console.debug(`[marimo-live] Slider polling complete after ${attempts} attempts`);
+    }
+  };
+
+  // Start after a short delay to let marimo initialize
+  setTimeout(check, 500);
+}
+
+/**
+ * Start a MutationObserver to watch for new slider elements.
+ * More efficient than polling for dynamic content.
+ */
+export function observeSliders(): MutationObserver | null {
+  if (typeof document === "undefined" || typeof MutationObserver === "undefined") {
+    return null;
+  }
+
+  const observer = new MutationObserver((mutations) => {
+    let foundNewSliders = false;
+
+    for (const mutation of mutations) {
+      // Check added nodes
+      for (const node of mutation.addedNodes) {
+        if (node.nodeType === Node.ELEMENT_NODE) {
+          const element = node as HTMLElement;
+
+          // Direct slider
+          if (element.tagName === "MARIMO-SLIDER") {
+            foundNewSliders = true;
+          }
+
+          // Sliders inside added subtree
+          if (element.querySelectorAll) {
+            const sliders = element.querySelectorAll("marimo-slider");
+            if (sliders.length > 0) {
+              foundNewSliders = true;
+            }
+          }
+        }
+      }
+    }
+
+    if (foundNewSliders) {
+      // Delay to let shadow root initialize
+      setTimeout(injectAllSliderStyles, 100);
+    }
+  });
+
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true,
+  });
+
+  console.log("[marimo-live] Slider observer started");
+  return observer;
+}
+
+/**
+ * Stop polling for sliders.
+ */
+export function stopPolling(): void {
+  if (pollingInterval) {
+    clearInterval(pollingInterval);
+    pollingInterval = null;
+  }
+  pollingStarted = false;
+}
+
+/**
+ * Reset slider styling state (for testing or HMR).
+ */
+export function resetSliderStyles(): void {
+  stopPolling();
+  styledSliders = new WeakSet();
+  console.log("[marimo-live] Slider styles reset");
+}
+
+/**
+ * Check if a specific slider has been styled.
+ */
+export function isSliderStyled(slider: HTMLElement): boolean {
+  return styledSliders.has(slider);
+}
+
+/**
+ * Check if polling is currently active.
+ */
+export function isPollingActive(): boolean {
+  return pollingStarted;
+}

--- a/slidev-addon-marimo-live/setup/slider-styles.ts
+++ b/slidev-addon-marimo-live/setup/slider-styles.ts
@@ -15,7 +15,7 @@
 
 // Track styling state
 let pollingStarted = false;
-let pollingInterval: ReturnType<typeof setInterval> | null = null;
+let pollingTimeoutId: ReturnType<typeof setTimeout> | null = null;
 let styledSliders = new WeakSet<HTMLElement>();
 
 /**
@@ -185,15 +185,16 @@ export function pollForSliders(maxAttempts = 40, intervalMs = 500): void {
 
     // Continue polling if under max attempts
     if (attempts < maxAttempts) {
-      setTimeout(check, intervalMs);
+      pollingTimeoutId = setTimeout(check, intervalMs);
     } else {
       pollingStarted = false;
+      pollingTimeoutId = null;
       console.debug(`[marimo-live] Slider polling complete after ${attempts} attempts`);
     }
   };
 
   // Start after a short delay to let marimo initialize
-  setTimeout(check, 500);
+  pollingTimeoutId = setTimeout(check, 500);
 }
 
 /**
@@ -249,9 +250,9 @@ export function observeSliders(): MutationObserver | null {
  * Stop polling for sliders.
  */
 export function stopPolling(): void {
-  if (pollingInterval) {
-    clearInterval(pollingInterval);
-    pollingInterval = null;
+  if (pollingTimeoutId) {
+    clearTimeout(pollingTimeoutId);
+    pollingTimeoutId = null;
   }
   pollingStarted = false;
 }

--- a/slidev-addon-marimo-live/styles/marimo-overrides.css
+++ b/slidev-addon-marimo-live/styles/marimo-overrides.css
@@ -1,0 +1,389 @@
+/**
+ * Marimo UI Overrides
+ *
+ * CSS overrides for marimo UI elements to integrate well with Slidev themes.
+ * These styles work alongside marimo's built-in styles to ensure consistent
+ * appearance across different presentation themes.
+ */
+
+/* ============================================
+   CSS Custom Properties for Theming
+   ============================================ */
+
+:root {
+  /* Primary colors */
+  --marimo-ui-primary: #3b82f6;
+  --marimo-ui-primary-hover: #2563eb;
+  --marimo-ui-primary-light: #93c5fd;
+
+  /* Background colors */
+  --marimo-ui-bg: #ffffff;
+  --marimo-ui-bg-muted: #f9fafb;
+  --marimo-ui-bg-hover: #f3f4f6;
+
+  /* Text colors */
+  --marimo-ui-text: #1f2937;
+  --marimo-ui-text-muted: #6b7280;
+
+  /* Border colors */
+  --marimo-ui-border: #e5e7eb;
+  --marimo-ui-border-focus: #3b82f6;
+
+  /* Status colors */
+  --marimo-ui-success: #22c55e;
+  --marimo-ui-error: #ef4444;
+  --marimo-ui-warning: #f59e0b;
+
+  /* Shadows */
+  --marimo-ui-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  --marimo-ui-shadow-lg: 0 4px 6px rgba(0, 0, 0, 0.1);
+
+  /* Radii */
+  --marimo-ui-radius: 6px;
+  --marimo-ui-radius-lg: 8px;
+}
+
+/* Dark mode overrides */
+.dark,
+[data-theme="dark"] {
+  --marimo-ui-primary: #60a5fa;
+  --marimo-ui-primary-hover: #93c5fd;
+  --marimo-ui-primary-light: #1e40af;
+
+  --marimo-ui-bg: #1f2937;
+  --marimo-ui-bg-muted: #374151;
+  --marimo-ui-bg-hover: #4b5563;
+
+  --marimo-ui-text: #f9fafb;
+  --marimo-ui-text-muted: #9ca3af;
+
+  --marimo-ui-border: #4b5563;
+  --marimo-ui-border-focus: #60a5fa;
+
+  --marimo-ui-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+  --marimo-ui-shadow-lg: 0 4px 6px rgba(0, 0, 0, 0.3);
+}
+
+/* ============================================
+   Marimo UI Element Overrides
+   ============================================ */
+
+/* Generic UI element container */
+marimo-ui-element {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 0.875rem;
+}
+
+/* Slider overrides */
+marimo-slider {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 150px;
+}
+
+marimo-slider label {
+  font-weight: 500;
+  color: var(--marimo-ui-text);
+}
+
+marimo-slider output {
+  min-width: 3ch;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  color: var(--marimo-ui-text-muted);
+}
+
+/* Dropdown overrides */
+marimo-dropdown {
+  display: inline-block;
+}
+
+marimo-dropdown select {
+  appearance: none;
+  background-color: var(--marimo-ui-bg);
+  border: 1px solid var(--marimo-ui-border);
+  border-radius: var(--marimo-ui-radius);
+  padding: 0.5rem 2rem 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  color: var(--marimo-ui-text);
+  cursor: pointer;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.5rem center;
+  transition: border-color 0.15s ease;
+}
+
+marimo-dropdown select:hover {
+  border-color: var(--marimo-ui-primary);
+}
+
+marimo-dropdown select:focus {
+  outline: none;
+  border-color: var(--marimo-ui-border-focus);
+  box-shadow: 0 0 0 2px var(--marimo-ui-primary-light);
+}
+
+/* Checkbox overrides */
+marimo-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+marimo-checkbox input[type="checkbox"] {
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--marimo-ui-primary);
+  cursor: pointer;
+}
+
+marimo-checkbox label {
+  color: var(--marimo-ui-text);
+  cursor: pointer;
+}
+
+/* Switch overrides */
+marimo-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* Text input overrides */
+marimo-text,
+marimo-text-area,
+marimo-number {
+  display: inline-block;
+}
+
+marimo-text input,
+marimo-number input {
+  background-color: var(--marimo-ui-bg);
+  border: 1px solid var(--marimo-ui-border);
+  border-radius: var(--marimo-ui-radius);
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  color: var(--marimo-ui-text);
+  transition: border-color 0.15s ease;
+}
+
+marimo-text input:focus,
+marimo-number input:focus {
+  outline: none;
+  border-color: var(--marimo-ui-border-focus);
+  box-shadow: 0 0 0 2px var(--marimo-ui-primary-light);
+}
+
+marimo-text-area textarea {
+  background-color: var(--marimo-ui-bg);
+  border: 1px solid var(--marimo-ui-border);
+  border-radius: var(--marimo-ui-radius);
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  color: var(--marimo-ui-text);
+  resize: vertical;
+  min-height: 60px;
+}
+
+marimo-text-area textarea:focus {
+  outline: none;
+  border-color: var(--marimo-ui-border-focus);
+  box-shadow: 0 0 0 2px var(--marimo-ui-primary-light);
+}
+
+/* Button overrides */
+marimo-button button {
+  background-color: var(--marimo-ui-primary);
+  color: white;
+  border: none;
+  border-radius: var(--marimo-ui-radius);
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+marimo-button button:hover {
+  background-color: var(--marimo-ui-primary-hover);
+}
+
+marimo-button button:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--marimo-ui-bg), 0 0 0 4px var(--marimo-ui-primary);
+}
+
+marimo-button button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Radio group overrides */
+marimo-radio {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+marimo-radio label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--marimo-ui-text);
+  cursor: pointer;
+}
+
+marimo-radio input[type="radio"] {
+  accent-color: var(--marimo-ui-primary);
+}
+
+/* Date picker overrides */
+marimo-date input[type="date"] {
+  background-color: var(--marimo-ui-bg);
+  border: 1px solid var(--marimo-ui-border);
+  border-radius: var(--marimo-ui-radius);
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  color: var(--marimo-ui-text);
+}
+
+marimo-date input[type="date"]:focus {
+  outline: none;
+  border-color: var(--marimo-ui-border-focus);
+  box-shadow: 0 0 0 2px var(--marimo-ui-primary-light);
+}
+
+/* ============================================
+   Table and DataFrame Overrides
+   ============================================ */
+
+marimo-table,
+marimo-dataframe {
+  display: block;
+  overflow-x: auto;
+  margin: 0.5rem 0;
+}
+
+marimo-table table,
+marimo-dataframe table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 0.8125rem;
+  background-color: var(--marimo-ui-bg);
+}
+
+marimo-table th,
+marimo-dataframe th {
+  background-color: var(--marimo-ui-bg-muted);
+  font-weight: 600;
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 2px solid var(--marimo-ui-border);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+marimo-table td,
+marimo-dataframe td {
+  padding: 0.375rem 0.75rem;
+  border-bottom: 1px solid var(--marimo-ui-border);
+}
+
+marimo-table tr:hover,
+marimo-dataframe tr:hover {
+  background-color: var(--marimo-ui-bg-hover);
+}
+
+/* ============================================
+   Chart and Visualization Overrides
+   ============================================ */
+
+marimo-chart,
+marimo-altair,
+marimo-plotly {
+  display: block;
+  width: 100%;
+  margin: 0.5rem 0;
+}
+
+marimo-chart canvas,
+marimo-altair svg,
+marimo-plotly .plotly {
+  max-width: 100%;
+  height: auto;
+}
+
+/* ============================================
+   Layout Components
+   ============================================ */
+
+marimo-accordion,
+marimo-tabs,
+marimo-tree {
+  display: block;
+  margin: 0.5rem 0;
+}
+
+marimo-callout {
+  display: block;
+  padding: 0.75rem 1rem;
+  border-radius: var(--marimo-ui-radius);
+  margin: 0.5rem 0;
+  background-color: var(--marimo-ui-bg-muted);
+  border-left: 4px solid var(--marimo-ui-primary);
+}
+
+marimo-stat {
+  display: inline-flex;
+  flex-direction: column;
+  padding: 0.75rem 1rem;
+  background-color: var(--marimo-ui-bg-muted);
+  border-radius: var(--marimo-ui-radius);
+  box-shadow: var(--marimo-ui-shadow);
+}
+
+marimo-progress {
+  display: block;
+  height: 0.5rem;
+  background-color: var(--marimo-ui-bg-muted);
+  border-radius: 9999px;
+  overflow: hidden;
+}
+
+marimo-progress > div {
+  height: 100%;
+  background-color: var(--marimo-ui-primary);
+  transition: width 0.3s ease;
+}
+
+/* ============================================
+   Slidev Integration
+   ============================================ */
+
+/* Scale down slightly in presentations */
+.slidev-layout marimo-ui-element,
+.slidev-layout marimo-slider,
+.slidev-layout marimo-dropdown,
+.slidev-layout marimo-checkbox,
+.slidev-layout marimo-switch,
+.slidev-layout marimo-text,
+.slidev-layout marimo-button {
+  font-size: 0.85rem;
+}
+
+/* Ensure UI elements don't break slide layouts */
+.slidev-layout .marimo-output {
+  overflow-x: auto;
+  max-width: 100%;
+}
+
+/* Reduce padding in compact slides */
+.slidev-layout[data-layout="compact"] marimo-callout,
+.slidev-layout[data-layout="compact"] marimo-stat {
+  padding: 0.5rem 0.75rem;
+}


### PR DESCRIPTION
## Summary
Validation and styling improvements for the marimo-live addon.

## Changes
- Enable interactive UI elements (sliders, dropdowns) via marimo frontend
- Redesign code blocks with One Dark Pro theme
- Fix code review feedback (debug logging, XSS safety, empty line handling)

## Testing
- Start marimo kernel: `marimo edit notebook.py --headless --port 2718`
- Start slidev: `bunx slidev examples/marimo-live-test.md --port 3033`
- Verify slider renders and code styling looks polished

🤖 Generated with [Claude Code](https://claude.com/claude-code)